### PR TITLE
Installing Qiita for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,17 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
+  - travis_retry conda create --yes -n qiita_env python=2.7 pip nose flake8
+    pyzmq networkx pyparsing natsort mock future libgfortran
+    'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
+  - source activate qiita_env
+  - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
+  - pip install https://github.com/biocore/qiita/archive/master.zip
+  - ipython profile create qiita-general --parallel
+  - qiita-env start_cluster qiita-general
+  - qiita-env make --no-load-ontologies
+  - qiita pet webserver start &
+  - source deactivate
   - travis_retry conda create --yes -n env_name python=$PYTHON_VERSION pip nose flake8 httpretty coverage
   - source activate env_name
   - travis_retry pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,10 @@ install:
 script:
   - nosetests --with-doctest --with-coverage
   - flake8 qiita_client setup.py
+addons:
+    postgresql: "9.3"
+services:
+    - redis-server
+    - postgresql
 after_success:
   - coveralls


### PR DESCRIPTION
This modifies the travis file to install Qiita in a different environment to see if we can run a Qiita server on the back to run the tests. This will reduce the burden on Qiita plugin development since we will not need to emulate Qiita's REST api. This always installs the "master" version of Qiita.