### PR TITLE
Adding equality comparator and fixing import

### DIFF
--- a/qiita_client/__init__.py
+++ b/qiita_client/__init__.py
@@ -8,7 +8,7 @@
 
 from .exceptions import (QiitaClientError, NotFoundError, BadRequestError,
                          ForbiddenError)
-from .qiita_client import QiitaClient
+from .qiita_client import QiitaClient, ArtifactInfo
 
 __all__ = ["QiitaClient", "QiitaClientError", "NotFoundError",
-           "BadRequestError", "ForbiddenError"]
+           "BadRequestError", "ForbiddenError", "ArtifactInfo"]

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -34,6 +34,15 @@ class ArtifactInfo(object):
         self.artifact_type = artifact_type
         self.files = files
 
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+        if self.output_name != other.output_name or \
+                self.artifact_type != other.artifact_type or \
+                set(self.files) != set(other.files):
+            return False
+        return True
+
 
 def _heartbeat(qclient, url):
     """Send the heartbeat calls to the server

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -43,6 +43,9 @@ class ArtifactInfo(object):
             return False
         return True
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 def _heartbeat(qclient, url):
     """Send the heartbeat calls to the server

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -29,6 +29,21 @@ class ArtifactInfoTests(TestCase):
         self.assertEqual(obs.artifact_type, 'Demultiplexed')
         self.assertEqual(obs.files, files)
 
+    def test_eq(self):
+        files = [("fp1", "preprocessed_fasta"), ("fp2", "preprocessed_fastq")]
+        obs = ArtifactInfo('demultiplexed', 'Demultiplexed', files)
+
+        self.assertTrue(obs == obs)
+        self.assertTrue(
+            obs == ArtifactInfo('demultiplexed', 'Demultiplexed', files))
+        files2 = [("fp2", "preprocessed_fastq"), ("fp1", "preprocessed_fasta")]
+        obs2 = ArtifactInfo('demultiplexed', 'Demultiplexed', files2)
+        self.assertTrue(obs == obs2)
+
+        self.assertFalse(obs == 1)
+        self.assertFalse(obs == ArtifactInfo('demux', 'Demultiplexed', files))
+        self.assertFalse(obs == ArtifactInfo('demultiplexed', 'Demux', files))
+
 
 class UtilTests(TestCase):
     def test_format_payload(self):

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -29,20 +29,20 @@ class ArtifactInfoTests(TestCase):
         self.assertEqual(obs.artifact_type, 'Demultiplexed')
         self.assertEqual(obs.files, files)
 
-    def test_eq(self):
+    def test_eq_ne(self):
         files = [("fp1", "preprocessed_fasta"), ("fp2", "preprocessed_fastq")]
         obs = ArtifactInfo('demultiplexed', 'Demultiplexed', files)
 
-        self.assertTrue(obs == obs)
-        self.assertTrue(
-            obs == ArtifactInfo('demultiplexed', 'Demultiplexed', files))
+        self.assertEqual(obs, obs)
+        self.assertEqual(
+            obs, ArtifactInfo('demultiplexed', 'Demultiplexed', files))
         files2 = [("fp2", "preprocessed_fastq"), ("fp1", "preprocessed_fasta")]
         obs2 = ArtifactInfo('demultiplexed', 'Demultiplexed', files2)
-        self.assertTrue(obs == obs2)
+        self.assertEqual(obs, obs2)
 
-        self.assertFalse(obs == 1)
-        self.assertFalse(obs == ArtifactInfo('demux', 'Demultiplexed', files))
-        self.assertFalse(obs == ArtifactInfo('demultiplexed', 'Demux', files))
+        self.assertNotEqual(obs, 1)
+        self.assertNotEqual(obs, ArtifactInfo('demux', 'Demultiplexed', files))
+        self.assertNotEqual(obs, ArtifactInfo('demultiplexed', 'Demux', files))
 
 
 class UtilTests(TestCase):


### PR DESCRIPTION
Make the artifact_info object importable from module and add the `__eq__` and `__ne__` functions so we can use the `assertEqual` functions in testing.