### PR TITLE
Making sure that Qiita reloads the plugins so tests can be run

### DIFF
--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -22,6 +22,7 @@ class PluginTestCase(TestCase):
         cls.qclient = QiitaClient("https://localhost:21174", cls.client_id,
                                   cls.client_secret,
                                   server_cert=cls.server_cert)
+        cls.qclient.post('/apitest/reload_plugins/')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Since the database is reseted after each execution of the tests, the plugins needs to be reloaded on the setUpClass to make sure the plugin is available.

cc @antgonza 