### PR TITLE
Adding analysis only param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx==1.5.5 sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
+  - pip install https://github.com/biocore/qiita/archive/analysis-refactor.zip --process-dependency-links
   - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,18 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
+  - pip install https://github.com/biocore/qiita/archive/analysis-refactor.zip --process-dependency-links
+  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
+  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general
   - qiita-env make --no-load-ontologies
-  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - source deactivate
   - travis_retry conda create --yes -n env_name python=$PYTHON_VERSION pip nose flake8 coverage
   - source activate env_name
   - travis_retry pip install .
 before_script:
   - source activate qiita_env
-  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - qiita pet webserver start &
 script:
   - source activate env_name

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     pyzmq networkx pyparsing natsort mock future libgfortran
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
-  - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
+  - pip install sphinx==1.5.5 sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
   - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
   - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/biocore/qiita/archive/analysis-refactor.zip --process-dependency-links
+  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
   - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -57,6 +57,9 @@ class QiitaCommand(object):
         The default parameter sets of the command, keyed by parameter set name.
         The values should be a dictionary in which keys are the parameter names
         and values are the specific value for each parameter
+    analysis_only : bool, optional
+        If true, the command will only be available on the analysis pipeline.
+        Default: False
 
     Raises
     ------
@@ -66,7 +69,8 @@ class QiitaCommand(object):
         If `function` does not accept 4 parameters
     """
     def __init__(self, name, description, function, required_parameters,
-                 optional_parameters, outputs, default_parameter_sets=None):
+                 optional_parameters, outputs, default_parameter_sets=None,
+                 analysis_only=False):
         self.name = name
         self.description = description
 
@@ -90,6 +94,7 @@ class QiitaCommand(object):
         self.optional_parameters = optional_parameters
         self.default_parameter_sets = default_parameter_sets
         self.outputs = outputs
+        self.analysis_only = analysis_only
 
     def __call__(self, qclient, server_url, job_id, output_dir):
         return self.function(qclient, server_url, job_id, output_dir)
@@ -196,7 +201,8 @@ class BaseQiitaPlugin(object):
                         'optional_parameters': dumps(cmd.optional_parameters),
                         'default_parameter_sets': dumps(
                             cmd.default_parameter_sets),
-                        'outputs': dumps(cmd.outputs)}
+                        'outputs': dumps(cmd.outputs),
+                        'analysis_only': cmd.analysis_only}
                 qclient.post('/qiita_db/plugins/%s/%s/commands/'
                              % (self.name, self.version), data=data)
 

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -8,6 +8,7 @@
 
 from unittest import TestCase
 from os import environ
+from time import sleep
 
 from qiita_client import QiitaClient
 
@@ -28,3 +29,29 @@ class PluginTestCase(TestCase):
     def tearDownClass(cls):
         # Reset the test database
         cls.qclient.post("/apitest/reset/")
+
+    def _wait_for_running_job(self, job_id):
+        """Waits until the given job is not in a running status
+
+        Parameters
+        ----------
+        job_id : str
+            The job it to wait for
+
+        Returns
+        -------
+        str
+            The status of the job
+
+        Notes
+        -----
+        This function only polls for five seconds. After those five seconds,
+        it returns whatever the last seen status for the given job
+        """
+        for i in range(10):
+            sleep(0.5)
+            status = self.qclient.get_job_info(job_id)['status']
+            if status != 'running':
+                break
+
+        return status

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -210,8 +210,9 @@ class QiitaPluginTest(PluginTestCase):
         job_id = self.qclient.post('/apitest/processing_job/',
                                    data=data)['job']
         tester("https://localhost:21174", job_id, self.outdir)
-        obs = self.qclient.get_job_info(job_id)
-        self.assertEqual(obs['status'], 'success')
+
+        status = self._wait_for_running_job(job_id)
+        self.assertEqual(status, 'success')
 
 if __name__ == '__main__':
     main()

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -220,7 +220,10 @@ class QiitaPluginTest(PluginTestCase):
         obs = self.qclient.get('/qiita_db/plugins/NewPlugin/0.0.1/')
         self.assertEqual(obs['name'], 'NewPlugin')
         self.assertEqual(obs['version'], '0.0.1')
-        self.assertItemsEqual(obs['commands'], ['NewCmd', 'NewCmdAnalysis'])
+        # I can't use assertItemsEqual because it is not available in py3
+        # and I can't user assertCountEqual because it is not avaialable in py2
+        self.assertEqual(sorted(obs['commands']),
+                         sorted(['NewCmd', 'NewCmdAnalysis']))
 
         # Create a new job
         data = {'command': dumps(['NewPlugin', '0.0.1', 'NewCmd']),

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -233,5 +233,6 @@ class QiitaPluginTest(PluginTestCase):
         status = self._wait_for_running_job(job_id)
         self.assertEqual(status, 'success')
 
+
 if __name__ == '__main__':
     main()

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -101,7 +101,8 @@ class QiitaClientTests(PluginTestCase):
             'visibility': 'private',
             'ebi_run_accessions': None,
             'type': 'FASTQ',
-            'name': 'Raw data 1'}
+            'name': 'Raw data 1',
+            'analysis': None}
 
         # Files contain the full path, which it is hard to test, so get only
         # the basename of the files


### PR DESCRIPTION
Modifying the command object and the register call so the command can register as a command that is only available in the analysis pipeline.