### PR TITLE
Giving enough time for the plugins to register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - travis_retry pip install .
 before_script:
   - source activate qiita
-  - qiita pet webserver start &
+  - qiita pet webserver --no-build-docs start &
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - travis_retry conda create --yes -n qiita_env python=2.7 pip nose flake8
+  - travis_retry conda create --yes -n qiita python=2.7 pip nose flake8
     pyzmq networkx pyparsing natsort mock future libgfortran
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
-  - source activate qiita_env
+  - source activate qiita
   - pip install sphinx==1.5.5 sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
   - pip install https://github.com/biocore/qiita/archive/analysis-refactor.zip --process-dependency-links
-  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
-  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
+  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_core/support_files/server.crt
+  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general
   - qiita-env make --no-load-ontologies
@@ -27,7 +27,7 @@ install:
   - source activate env_name
   - travis_retry pip install .
 before_script:
-  - source activate qiita_env
+  - source activate qiita
   - qiita pet webserver start &
 script:
   - source activate env_name

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -24,6 +24,8 @@ class PluginTestCase(TestCase):
                                   cls.client_secret,
                                   server_cert=cls.server_cert)
         cls.qclient.post('/apitest/reload_plugins/')
+        # Give enough time for the plugins to register
+        sleep(3)
 
     @classmethod
     def tearDownClass(cls):

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -50,7 +50,7 @@ class PluginTestCase(TestCase):
         This function only polls for five seconds. After those five seconds,
         it returns whatever the last seen status for the given job
         """
-        for i in range(10):
+        for i in range(20):
             sleep(0.5)
             status = self.qclient.get_job_info(job_id)['status']
             if status != 'running':


### PR DESCRIPTION
After reloading the plugins in a test environment, they need some time to register themselves. Various tests on my machine suggest that 3 seconds are enough.