### PR TITLE
Bad request visibility fix

### DIFF
--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -239,12 +239,12 @@ class QiitaClient(object):
             except ValueError:
                 r_json = None
 
-            if r_json and r_json['error_description'] == \
-                    'Oauth2 error: token has timed out':
-                # The token expired - get a new one and re-try the request
-                self._fetch_token()
-                kwargs['headers']['Authorization'] = 'Bearer %s' % self._token
-                r = req(*args, **kwargs)
+            if r_json and 'error_description' in r_json:
+                if r_json['error_description'] == 'Oauth2 error: token has timed out':
+                    # The token expired - get a new one and re-try the request
+                    self._fetch_token()
+                    kwargs['headers']['Authorization'] = 'Bearer %s' % self._token
+                    r = req(*args, **kwargs)
         return r
 
     def _request_retry(self, req, url, **kwargs):


### PR DESCRIPTION
When attempting to make a PATCH request to /api/v1/study/1/samples, with
obviously bad parameters, an exception was being raised server-side, and
therefore a descriptive error message was not being returned to the user
from qiita_client.

Bug appears to be the assumption that 'error_description' is present as
a key in r_json. A check has been added for the key.