### PR TITLE
Client: Separate plugin file system

### DIFF
--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -95,6 +95,7 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
+          sed -i "s/ENABLE_HTTPS_PLUGIN_FILETRANSFER = False/ENABLE_HTTPS_PLUGIN_FILETRANSFER = True/" ${QIITA_CONFIG_FP}
 
           export REDBIOM_HOST="http://localhost:7379"
 

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -106,7 +106,7 @@ jobs:
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
-          sed -i "s#/Users/username/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE_NEW}
+          sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -94,7 +94,7 @@ jobs:
           conda activate qiita
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
-          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
 
           export REDBIOM_HOST="http://localhost:7379"
 

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -105,8 +105,8 @@ jobs:
           mkdir -p ${CONDA_PREFIX}/var/run/nginx/
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
-          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
-          sed "s#/Users/username/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          sed -i "s#/Users/username/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE_NEW}
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -52,9 +52,8 @@ jobs:
 
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          # wget https://github.com/biocore/qiita/archive/dev.zip
-          # unzip dev.zip
-          git clone -b uncouplePlugins https://github.com/jlab/qiita.git qiita-dev
+          wget https://github.com/biocore/qiita/archive/dev.zip
+          unzip dev.zip
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}
@@ -95,7 +94,6 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
-          sed -i "s/ENABLE_HTTPS_PLUGIN_FILETRANSFER = False/ENABLE_HTTPS_PLUGIN_FILETRANSFER = True/" ${QIITA_CONFIG_FP}
 
           export REDBIOM_HOST="http://localhost:7379"
 

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -52,8 +52,9 @@ jobs:
 
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          wget https://github.com/biocore/qiita/archive/dev.zip
-          unzip dev.zip
+          # wget https://github.com/biocore/qiita/archive/dev.zip
+          # unzip dev.zip
+          git clone -b uncouplePlugins https://github.com/jlab/qiita.git
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -54,7 +54,7 @@ jobs:
           # all config files
           # wget https://github.com/biocore/qiita/archive/dev.zip
           # unzip dev.zip
-          git clone -b uncouplePlugins https://github.com/jlab/qiita.git
+          git clone -b uncouplePlugins https://github.com/jlab/qiita.git qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -106,6 +106,7 @@ jobs:
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          sed "s#/Users/username/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ cloud environments, default is **filesystem**.
 
 The plugin coupling protocoll can be set in three ways
 
-    1. default is always "filesystem", i.e. _DEFAULT_PLUGIN_COUPLINGS
-        This is to be downward compatible.
-    2. the plugin configuration can hold a section 'network' with an
-        option 'PLUGINCOUPLING'. For old config files, this might not
-        (yet) be the case. Therefore, we are double checking existance
-        of this section and parameter here.
-    3. you can set the environment variable QIITA_PLUGINCOUPLING
-        Precedence is 3, 2, 1, i.e. the environment variable overrides the
-        other two ways.
+1. default is always `filesystem`, i.e. `_DEFAULT_PLUGIN_COUPLINGS`
+   This is to be downward compatible.
+2. the plugin configuration can hold a section `network` with an
+   option `PLUGINCOUPLING`. For old config files, this might not
+   (yet) be the case. Therefore, we are double checking existance
+   of this section and parameter here.
+3. you can set the environment variable `QIITA_PLUGINCOUPLING`
+   Precedence is 3, 2, 1, i.e. the environment variable overrides
+   the other two ways.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,32 @@ Also, if Qiita is running with the default server SSL certificate, you need to e
 
 export QIITA_ROOT_CA=<QIITA_INSTALL_PATH>/qiita_core/support_files/ci_rootca.crt
 ```
+
+Configure for cloud computing
+-----------------------------
+In the default scenario, Qiita main and Qiita plugins are executed on the same
+machines, maybe spread across a Slurm or other grid compute cluster, but main
+and plugins have direct access to all files in `BASE_DATA_DIR`.
+
+This can be different, if you set up Qiita within a cloud compute environment,
+where main and plugins do **not** share one file system. In this case, input-
+files must first be transferred from main to plugin, then plugin can do its
+processing and resulting files must be transferred back to main, once
+processing is finished. To achieve this, the qiita_client, as it is part of
+each plugin, provides the two functions for this file transfer
+`fetch_file_from_central` and `push_file_to_central`. According to
+`self._plugincoupling`, these functions operate on different "protocols";
+as of 2025-08-29, either "filesystem" or "https". Switch to **"https"** for
+cloud environments, default is **filesystem**.
+
+The plugin coupling protocoll can be set in three ways
+
+    1. default is always "filesystem", i.e. _DEFAULT_PLUGIN_COUPLINGS
+        This is to be downward compatible.
+    2. the plugin configuration can hold a section 'network' with an
+        option 'PLUGINCOUPLING'. For old config files, this might not
+        (yet) be the case. Therefore, we are double checking existance
+        of this section and parameter here.
+    3. you can set the environment variable QIITA_PLUGINCOUPLING
+        Precedence is 3, 2, 1, i.e. the environment variable overrides the
+        other two ways.

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -136,11 +136,11 @@ class QiitaArtifactType(object):
 
 
 class BaseQiitaPlugin(object):
-    # default must be first element
-    _ALLOWED_PLUGIN_COUPLINGS = ['filesystem', 'https']
+    _DEFAULT_PLUGIN_COUPLINGS = 'filesystem'
+    _ALLOWED_PLUGIN_COUPLINGS = [_DEFAULT_PLUGIN_COUPLINGS, 'https']
 
     def __init__(self, name, version, description, publications=None,
-                 plugincoupling=_ALLOWED_PLUGIN_COUPLINGS[0]):
+                 plugincoupling=_DEFAULT_PLUGIN_COUPLINGS):
         logger.debug('Entered BaseQiitaPlugin.__init__()')
         self.name = name
         self.version = version
@@ -185,7 +185,7 @@ class BaseQiitaPlugin(object):
         self.conf_fp = join(conf_dir, "%s_%s.conf" % (self.name, self.version))
 
     def generate_config(self, env_script, start_script, server_cert=None,
-                        plugin_coupling=_ALLOWED_PLUGIN_COUPLINGS[0]):
+                        plugin_coupling=_DEFAULT_PLUGIN_COUPLINGS):
         """Generates the plugin configuration file
 
         Parameters
@@ -201,7 +201,7 @@ class BaseQiitaPlugin(object):
             HTTPS to it
         plugin_coupling : str
             Type of coupling of plugin to central for file exchange.
-            Valid values are 'filesystem' and 'https'.
+            Valid values: see _ALLOWED_PLUGIN_COUPLINGS.
         """
         logger.debug('Entered BaseQiitaPlugin.generate_config()')
         sr = SystemRandom()
@@ -283,8 +283,8 @@ class BaseQiitaPlugin(object):
             config.readfp(conf_file)
 
         # the plugin coupling protocoll can be set in three ways
-        # 1. default is always "filesystem", i.e. first value in
-        #    _ALLOWED_PLUGIN_COUPLINGS. This is to be downward compatible.
+        # 1. default is always "filesystem", i.e. _DEFAULT_PLUGIN_COUPLINGS
+        #    This is to be downward compatible.
         # 2. the plugin configuration can hold a section 'network' with an
         #    option 'PLUGINCOUPLING'. For old config files, this might not
         #    (yet) be the case. Therefore, we are double checking existance
@@ -292,7 +292,7 @@ class BaseQiitaPlugin(object):
         # 3. you can set the environment variable QIITA_PLUGINCOUPLING
         # Precedence is 3, 2, 1, i.e. the environment variable overrides the
         # other two ways.
-        plugincoupling = self._ALLOWED_PLUGIN_COUPLINGS[0]
+        plugincoupling = self._DEFAULT_PLUGIN_COUPLINGS
         if config.has_section('network') and \
            config.has_option('network', 'PLUGINCOUPLING'):
             plugincoupling = config.get('network', 'PLUGINCOUPLING')
@@ -372,7 +372,7 @@ class QiitaTypePlugin(BaseQiitaPlugin):
 
     def __init__(self, name, version, description, validate_func,
                  html_generator_func, artifact_types, publications=None,
-                 plugincoupling=BaseQiitaPlugin._ALLOWED_PLUGIN_COUPLINGS[0]):
+                 plugincoupling=BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS):
         super(QiitaTypePlugin, self).__init__(name, version, description,
                                               publications=publications,
                                               plugincoupling=plugincoupling)

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -185,7 +185,7 @@ class BaseQiitaPlugin(object):
         self.conf_fp = join(conf_dir, "%s_%s.conf" % (self.name, self.version))
 
     def generate_config(self, env_script, start_script, server_cert=None,
-                        plugin_couling=_ALLOWED_PLUGIN_COUPLINGS[0]):
+                        plugin_coupling=_ALLOWED_PLUGIN_COUPLINGS[0]):
         """Generates the plugin configuration file
 
         Parameters
@@ -216,7 +216,7 @@ class BaseQiitaPlugin(object):
                                      env_script, start_script,
                                      self._plugin_type, self.publications,
                                      server_cert, client_id, client_secret,
-                                     plugin_couling))
+                                     plugin_coupling))
 
     def _register_command(self, command):
         """Registers a command in the plugin

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -282,16 +282,6 @@ class BaseQiitaPlugin(object):
         with open(self.conf_fp, 'U') as conf_file:
             config.readfp(conf_file)
 
-        # the plugin coupling protocoll can be set in three ways
-        # 1. default is always "filesystem", i.e. _DEFAULT_PLUGIN_COUPLINGS
-        #    This is to be downward compatible.
-        # 2. the plugin configuration can hold a section 'network' with an
-        #    option 'PLUGINCOUPLING'. For old config files, this might not
-        #    (yet) be the case. Therefore, we are double checking existance
-        #    of this section and parameter here.
-        # 3. you can set the environment variable QIITA_PLUGINCOUPLING
-        # Precedence is 3, 2, 1, i.e. the environment variable overrides the
-        # other two ways.
         plugincoupling = self._DEFAULT_PLUGIN_COUPLINGS
         if config.has_section('network') and \
            config.has_option('network', 'PLUGINCOUPLING'):

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -136,33 +136,44 @@ class QiitaArtifactType(object):
 
 
 class BaseQiitaPlugin(object):
-    _ALLOWED_PLUGIN_COUPLINGS = ['filesystem', 'https']  # default must be first element
-    def __init__(self, name, version, description, publications=None, plugincoupling=_ALLOWED_PLUGIN_COUPLINGS[0]):
+    # default must be first element
+    _ALLOWED_PLUGIN_COUPLINGS = ['filesystem', 'https']
+
+    def __init__(self, name, version, description, publications=None,
+                 plugincoupling=_ALLOWED_PLUGIN_COUPLINGS[0]):
         logger.debug('Entered BaseQiitaPlugin.__init__()')
         self.name = name
         self.version = version
         self.description = description
         self.publications = dumps(publications) if publications else ""
 
-        # Depending on your compute architecture, there are multiple options available how
-        # "thight" plugins are coupled to the central Qiita master/workers
+        # Depending on your compute architecture, there are multiple options
+        # available how "thight" plugins are coupled to the central
+        # Qiita master/workers
         # --- filesystem ---
-        # The default scenario is "filesystem", i.e. plugins as well as master/worker have
-        # unrestricted direct access to a shared filesystem, e.g. a larger volume / directory,
-        # defined in the server configuration as base_data_dir
+        # The default scenario is "filesystem", i.e. plugins as well as
+        # master/worker have unrestricted direct access to a shared filesystem,
+        # e.g. a larger volume / directory, defined in the server configuration
+        # as base_data_dir
         # --- https ---
-        # A second scenario is that your plugins execute as independent jobs on another machine,
-        # e.g. as docker containers or other cloud techniques. Intentionally, you don't want to
-        # use a shared filesystem, but you have to make sure necessary input files are 
-        # provided to the containerized plugin before execution and resulting files are
-        # transfered back to the central Qiita master/worker. In this case, files are
-        # pulled / pushed through functions qiita_client.fetch_file_from_central and
+        # A second scenario is that your plugins execute as independent jobs on
+        # another machine, e.g. as docker containers or other cloud techniques.
+        # Intentionally, you don't want to use a shared filesystem, but you
+        # have to make sure necessary input files are provided to the
+        # containerized plugin before execution and resulting files are
+        # transfered back to the central Qiita master/worker. In this case,
+        # files are pulled / pushed through functions
+        # qiita_client.fetch_file_from_central and
         # qiita_client.push_file_to_central, respectivey.
-        # Actually, all files need to be decorated with this function. The decision how
-        # data are transferred is then made within these two functions according to the
-        # "plugincoupling" setting.
+        # Actually, all files need to be decorated with this function.
+        # The decision how data are transferred is then made within these two
+        # functions according to the "plugincoupling" setting.
         if plugincoupling not in self._ALLOWED_PLUGIN_COUPLINGS:
-            raise ValueError("valid plugincoupling values are ['%s'], but you provided %s" % ("', '".join(self._ALLOWED_PLUGIN_COUPLINGS), plugincoupling))
+            raise ValueError(
+                ("valid plugincoupling values are ['%s'], but you "
+                 "provided %s") % (
+                     "', '".join(self._ALLOWED_PLUGIN_COUPLINGS),
+                     plugincoupling))
         self.plugincoupling = plugincoupling
 
         # Will hold the different commands
@@ -173,7 +184,8 @@ class BaseQiitaPlugin(object):
             'QIITA_PLUGINS_DIR', join(expanduser('~'), '.qiita_plugins'))
         self.conf_fp = join(conf_dir, "%s_%s.conf" % (self.name, self.version))
 
-    def generate_config(self, env_script, start_script, server_cert=None, plugin_couling=_ALLOWED_PLUGIN_COUPLINGS[0]):
+    def generate_config(self, env_script, start_script, server_cert=None,
+                        plugin_couling=_ALLOWED_PLUGIN_COUPLINGS[0]):
         """Generates the plugin configuration file
 
         Parameters
@@ -188,7 +200,7 @@ class BaseQiitaPlugin(object):
             path to the Qiita certificate so the plugin can connect over
             HTTPS to it
         plugin_coupling : str
-            Type of coupling of plugin to central for file exchange. 
+            Type of coupling of plugin to central for file exchange.
             Valid values are 'filesystem' and 'https'.
         """
         logger.debug('Entered BaseQiitaPlugin.generate_config()')
@@ -214,7 +226,8 @@ class BaseQiitaPlugin(object):
         command: QiitaCommand
             The command to be added to the plugin
         """
-        logger.debug('Entered BaseQiitaPlugin._register_command(%s)' % command.name)
+        logger.debug('Entered BaseQiitaPlugin._register_command(%s)' %
+                     command.name)
         self.task_dict[command.name] = command
 
     def _register(self, qclient):
@@ -277,7 +290,8 @@ class BaseQiitaPlugin(object):
                               # from validating the server's cert using
                               # certifi's pem cache.
                               ca_cert=config.get('oauth2', 'SERVER_CERT'),
-                              plugincoupling=config.get('network', 'PLUGINCOUPLING'))
+                              plugincoupling=config.get('network',
+                                                        'PLUGINCOUPLING'))
 
         if job_id == 'register':
             self._register(qclient)

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -773,7 +773,7 @@ class QiitaClient(object):
         str : the filepath of the requested file within the local file system
         """
         target_filepath = filepath
-        if not prefix:
+        if (prefix is not None) and (prefix != ""):
             # strip off root
             if filepath.startswith(os.path.abspath(os.sep)):
                 target_filepath = target_filepath[
@@ -782,7 +782,7 @@ class QiitaClient(object):
             target_filepath = os.path.join(prefix, target_filepath)
 
         if self._plugincoupling == 'filesystem':
-            if not prefix:
+            if (prefix is not None) and (prefix != ""):
                 # create necessary directory locally
                 os.makedirs(os.path.dirname(target_filepath), exist_ok=True)
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -744,7 +744,7 @@ class QiitaClient(object):
 
         return sample_names, prep_info
 
-    def fetch_file_from_central(self, filepath, prefix=''):
+    def fetch_file_from_central(self, filepath, prefix=None):
         """Moves content of a file from Qiita's central BASE_DATA_DIR to a
            local plugin file-system.
 
@@ -764,7 +764,7 @@ class QiitaClient(object):
             Primarily for testing: prefix the target filepath with this
             filepath prefix to
             a) in 'filesystem' mode: create an actual file copy (for testing)
-               If prefix='', nothing will be copied/moved
+               If prefix=None, nothing will be copied/moved
             b) in 'https' mode: flexibility to locate files differently in
                plugin local file system.
 
@@ -773,7 +773,7 @@ class QiitaClient(object):
         str : the filepath of the requested file within the local file system
         """
         target_filepath = filepath
-        if prefix != '':
+        if (prefix is not None) and (prefix != ""):
             # strip off root
             if filepath.startswith(os.path.abspath(os.sep)):
                 target_filepath = target_filepath[

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -790,6 +790,10 @@ class QiitaClient(object):
             return target_filepath
 
         elif self._plugincoupling == 'https':
+            # strip off root
+            if filepath.startswith(os.path.abspath(os.sep)):
+                filepath = filepath[len(os.path.abspath(os.sep)):]
+
             logger.debug('Requesting file %s from qiita server.' % filepath)
 
             # actual call to Qiita central to obtain file content

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -773,7 +773,7 @@ class QiitaClient(object):
         str : the filepath of the requested file within the local file system
         """
         target_filepath = filepath
-        if (prefix is not None) and (prefix != ""):
+        if not prefix:
             # strip off root
             if filepath.startswith(os.path.abspath(os.sep)):
                 target_filepath = target_filepath[
@@ -782,7 +782,7 @@ class QiitaClient(object):
             target_filepath = os.path.join(prefix, target_filepath)
 
         if self._plugincoupling == 'filesystem':
-            if prefix != '':
+            if not prefix:
                 # create necessary directory locally
                 os.makedirs(os.path.dirname(target_filepath), exist_ok=True)
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -744,7 +744,7 @@ class QiitaClient(object):
         return sample_names, prep_info
 
     def fetch_file_from_central(self, filepath, prefix=''):
-        """Moves content of a file from Qiita's central base_data_dir to a
+        """Moves content of a file from Qiita's central BASE_DATA_DIR to a
            local plugin file-system.
 
            By default, this is exactly the same location, i.e. the return
@@ -752,12 +752,12 @@ class QiitaClient(object):
            copied.
            However, for less tight plugin couplings, file content can be
            transferred via https for situations where the plugin does not have
-           native access to Qiita's overall base_data_dir.
+           native access to Qiita's overall BASE_DATA_DIR.
 
         Parameters
         ----------
         filepath : str
-            The filepath in Qiita's central base_data_dir to the requested
+            The filepath in Qiita's central BASE_DATA_DIR to the requested
             file content
         prefix : str
             Primarily for testing: prefix the target filepath with this
@@ -812,9 +812,9 @@ class QiitaClient(object):
                  "configuration is NOT defined.") % self._plugincoupling)
 
     def push_file_to_central(self, filepath):
-        """Pushs filecontent to Qiita's central base_data_dir directory.
+        """Pushs filecontent to Qiita's central BASE_DATA_DIR directory.
 
-        By default, plugin and Qiita's central base_data_dir filesystems are
+        By default, plugin and Qiita's central BASE_DATA_DIR filesystems are
         identical. In this case, no files are touched and the filepath is
         directly returned.
         If however, plugincoupling is set to 'https', the content of the file
@@ -825,7 +825,7 @@ class QiitaClient(object):
         ----------
         filepath : str
             The filepath of the files whos content shall be send to Qiita's
-            central base_data_dir
+            central BASE_DATA_DIR
 
         Returns
         -------

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -812,6 +812,25 @@ class QiitaClient(object):
                  "configuration is NOT defined.") % self._plugincoupling)
 
     def push_file_to_central(self, filepath):
+        """Pushs filecontent to Qiita's central base_data_dir directory.
+
+        By default, plugin and Qiita's central base_data_dir filesystems are
+        identical. In this case, no files are touched and the filepath is
+        directly returned.
+        If however, plugincoupling is set to 'https', the content of the file
+        is sent via https POST to Qiita's master/worker, which has to receive
+        and store in an appropriate location.
+
+        Parameters
+        ----------
+        filepath : str
+            The filepath of the files whos content shall be send to Qiita's
+            central base_data_dir
+
+        Returns
+        -------
+        The given filepath - to be transparent in plugin code.
+        """
         if self._plugincoupling == 'filesystem':
             return filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -841,9 +841,14 @@ class QiitaClient(object):
         elif self._plugincoupling == 'https':
             logger.debug('Submitting file %s to qiita server.' % filepath)
 
+            # target path, i.e. without filename
+            dirpath = os.path.dirname(filepath)
+            if dirpath == "":
+                dirpath = "/"
+
             self.post(
                 '/cloud/push_file_to_central/',
-                files={os.path.dirname(filepath): open(filepath, 'rb')})
+                files={dirpath: open(filepath, 'rb')})
 
             return filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -183,7 +183,8 @@ class QiitaClient(object):
     get
     post
     """
-    def __init__(self, server_url, client_id, client_secret, ca_cert=None, plugincoupling='filesystem'):
+    def __init__(self, server_url, client_id, client_secret, ca_cert=None,
+                 plugincoupling='filesystem'):
         self._server_url = server_url
         self._session = requests.Session()
 
@@ -367,7 +368,8 @@ class QiitaClient(object):
         retries = MAX_RETRIES
         while retries > 0:
             retries -= 1
-            r = self._request_oauth2(req, rettype, url, verify=self._verify, **kwargs)
+            r = self._request_oauth2(
+                req, rettype, url, verify=self._verify, **kwargs)
             r.close()
             # There are some error codes that the specification says that they
             # shouldn't be retried
@@ -389,7 +391,10 @@ class QiitaClient(object):
                         if rettype == 'content':
                             return r.content
                         else:
-                            raise ValueError("return type rettype='%s' cannot be understand. Choose from 'json' (default) or 'content!" % rettype)
+                            raise ValueError(
+                                ("return type rettype='%s' cannot be "
+                                 "understand. Choose from 'json' (default) "
+                                 "or 'content!") % rettype)
                 except ValueError:
                     return None
             stime = randint(MIN_TIME_SLEEP, MAX_TIME_SLEEP)
@@ -420,7 +425,8 @@ class QiitaClient(object):
             The JSON response from the server
         """
         logger.debug('Entered QiitaClient.get()')
-        return self._request_retry(self._session.get, url, rettype=rettype, **kwargs)
+        return self._request_retry(
+            self._session.get, url, rettype=rettype, **kwargs)
 
     def post(self, url, **kwargs):
         """Execute a post request against the Qiita server
@@ -438,7 +444,8 @@ class QiitaClient(object):
             The JSON response from the server
         """
         logger.debug('Entered QiitaClient.post(%s)' % url)
-        return self._request_retry(self._session.post, url, rettype='json', **kwargs)
+        return self._request_retry(
+            self._session.post, url, rettype='json', **kwargs)
 
     def patch(self, url, op, path, value=None, from_p=None, **kwargs):
         """Executes a JSON patch request against the Qiita server
@@ -497,7 +504,8 @@ class QiitaClient(object):
         # we made sure that data is correctly formatted here
         kwargs['data'] = data
 
-        return self._request_retry(self._session.patch, url, rettype='json', **kwargs)
+        return self._request_retry(
+            self._session.patch, url, rettype='json', **kwargs)
 
     # The functions are shortcuts for common functionality that all plugins
     # need to implement.
@@ -520,7 +528,8 @@ class QiitaClient(object):
             The JSON response from the server
         """
         logger.debug('Entered QiitaClient.http_patch()')
-        return self._request_retry(self._session.patch, url, rettype='json', **kwargs)
+        return self._request_retry(
+            self._session.patch, url, rettype='json', **kwargs)
 
     def start_heartbeat(self, job_id):
         """Create and start a thread that would send heartbeats to the server
@@ -741,7 +750,9 @@ class QiitaClient(object):
             logger.debug('Requesting file %s from qiita server.' % filepath)
 
             # actual call to Qiita central to obtain file content
-            content = self.get('/cloud/fetch_file_from_central/' + filepath, rettype='content')
+            content = self.get(
+                '/cloud/fetch_file_from_central/' + filepath,
+                rettype='content')
 
             # create necessary directory locally
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
@@ -752,7 +763,9 @@ class QiitaClient(object):
 
             return filepath
 
-        raise ValueError("File communication protocol '%s' as defined in plugins configuration is NOT defined." % self._plugincoupling)
+        raise ValueError(
+            ("File communication protocol '%s' as defined in plugins "
+             "configuration is NOT defined.") % self._plugincoupling)
 
     def push_file_to_central(self, filepath):
         if self._plugincoupling == 'filesystem':
@@ -761,9 +774,12 @@ class QiitaClient(object):
         if self._plugincoupling == 'https':
             logger.debug('Submitting file %s to qiita server.' % filepath)
 
-            self.post('/cloud/push_file_to_central/',
+            self.post(
+                '/cloud/push_file_to_central/',
                 files={os.path.dirname(filepath): open(filepath, 'rb')})
 
             return filepath
 
-        raise ValueError("File communication protocol '%s' as defined in plugins configuration is NOT defined." % self._plugincoupling)
+        raise ValueError(
+            ("File communication protocol '%s' as defined in plugins "
+             "configuration is NOT defined.") % self._plugincoupling)

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -221,6 +221,7 @@ class QiitaClient(object):
         self._token = None
         self._fetch_token()
 
+        # store protocol for plugin coupling
         self._plugincoupling = plugincoupling
 
     def _fetch_token(self):

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -150,7 +150,7 @@ class QiitaTypePluginTest(PluginTestCase):
                      'SERVER_CERT = \n',
                      '\n',
                      '[network]\n',
-                     'plugincoupling = \n']
+                     'PLUGINCOUPLING = \n']
         # We will test the last 2 lines independently since they're variable
         # in each test run
         self.assertEqual(conf[:-2], exp_lines)

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -154,7 +154,7 @@ class QiitaTypePluginTest(PluginTestCase):
         self.assertTrue(conf[-5].startswith('CLIENT_ID = '))
         self.assertTrue(conf[-4].startswith('CLIENT_SECRET = '))
         self.assertTrue(conf[-2].startswith('[network]'))
-        self.assertTrue(conf[-2].startswith('PLUGINCOUPLING = '))
+        self.assertTrue(conf[-1].startswith('PLUGINCOUPLING = '))
 
     def test_call(self):
         def validate_func(a, b, c, d):

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -147,7 +147,10 @@ class QiitaTypePluginTest(PluginTestCase):
                      'PUBLICATIONS = \n',
                      '\n',
                      '[oauth2]\n',
-                     'SERVER_CERT = \n']
+                     'SERVER_CERT = \n',
+                     '\n',
+                     '[network]\n',
+                     'plugincoupling = \n']
         # We will test the last 2 lines independently since they're variable
         # in each test run
         self.assertEqual(conf[:-2], exp_lines)

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -147,15 +147,14 @@ class QiitaTypePluginTest(PluginTestCase):
                      'PUBLICATIONS = \n',
                      '\n',
                      '[oauth2]\n',
-                     'SERVER_CERT = \n',
-                     '\n',
-                     '[network]\n',
-                     'PLUGINCOUPLING = \n']
+                     'SERVER_CERT = \n']
         # We will test the last 2 lines independently since they're variable
         # in each test run
-        self.assertEqual(conf[:-2], exp_lines)
-        self.assertTrue(conf[-2].startswith('CLIENT_ID = '))
-        self.assertTrue(conf[-1].startswith('CLIENT_SECRET = '))
+        self.assertEqual(conf[:-5], exp_lines)
+        self.assertTrue(conf[-5].startswith('CLIENT_ID = '))
+        self.assertTrue(conf[-4].startswith('CLIENT_SECRET = '))
+        self.assertTrue(conf[-2].startswith('[network]'))
+        self.assertTrue(conf[-2].startswith('PLUGINCOUPLING = '))
 
     def test_call(self):
         def validate_func(a, b, c, d):

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -397,7 +397,7 @@ class QiitaClientTests(PluginTestCase):
         self.assertEqual(fp, fp_obs)
 
         # mode: filesystem, prefix='/karl': make file copy
-        prefix = join(expanduser("~"), '/karl')
+        prefix = join(expanduser("~"), 'karl')
         self.clean_up_files.append(prefix + fp)
         fp_obs = self.tester.fetch_file_from_central(fp, prefix=prefix)
         self.assertEqual(prefix + fp, fp_obs)

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -385,6 +385,17 @@ class QiitaClientTests(PluginTestCase):
         self.assertEqual(fobs, fexp)
         self.assertEqual(piobs.shape, (2, 1))
 
+    def test_fetch_file_from_central(self):
+        self.tester._plugincoupling = 'filesystem'
+
+        ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
+        print("STEFAN", ainfo)
+
+        # fp_query = '/home/runner/work/qiita/qiita/qiita_db/support_files/
+        # test_data/templates/FASTA_QUAL_preprocessing_sample_template.txt'
+        # fp_res = fetch_file_from_central('')
+        pass
+
 
 if __name__ == '__main__':
     main()

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -412,35 +412,33 @@ class QiitaClientTests(PluginTestCase):
         self.tester._plugincoupling = 'https'
         prefix = join(expanduser("~"), 'kurt')
         self.clean_up_files.append(prefix + fp)
-        print("STEFAN", fp, prefix)
         fp_obs = self.tester.fetch_file_from_central(fp, prefix=prefix)
-        print("STEFAN2", fp_obs)
         self.assertEqual(prefix + fp, fp_obs)
         self.assertTrue(filecmp.cmp(fp, fp_obs, shallow=False))
 
-    # def test_push_file_to_central(self):
-    #     self.tester._plugincoupling = 'filesystem'
+    def test_push_file_to_central(self):
+        self.tester._plugincoupling = 'filesystem'
 
-    #     ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
-    #     fp = ainfo['files']['raw_forward_seqs'][0]['filepath']
+        ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
+        fp = ainfo['files']['raw_forward_seqs'][0]['filepath']
 
-    #     # mode: filesystem
-    #     fp_obs = self.tester.push_file_to_central(fp)
-    #     self.assertEqual(fp, fp_obs)
+        # mode: filesystem
+        fp_obs = self.tester.push_file_to_central(fp)
+        self.assertEqual(fp, fp_obs)
 
-    #     # non existing mode
-    #     with self.assertRaises(ValueError):
-    #         self.tester._plugincoupling = 'foo'
-    #         self.tester.push_file_to_central(fp)
+        # non existing mode
+        with self.assertRaises(ValueError):
+            self.tester._plugincoupling = 'foo'
+            self.tester.push_file_to_central(fp)
 
-    #     # change transfer mode to https
-    #     self.tester._plugincoupling = 'https'
-    #     fp_source = 'foo.bar'
-    #     with open(fp_source, 'w') as f:
-    #         f.write("this is a test\n")
-    #     self.clean_up_files.append(fp_source)
-    #     fp_obs = self.tester.push_file_to_central(fp_source)
-    #     self.assertEqual(fp_source, fp_obs)
+        # change transfer mode to https
+        self.tester._plugincoupling = 'https'
+        fp_source = 'foo.bar'
+        with open(fp_source, 'w') as f:
+            f.write("this is a test\n")
+        self.clean_up_files.append(fp_source)
+        fp_obs = self.tester.push_file_to_central(fp_source)
+        self.assertEqual(fp_source, fp_obs)
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -412,33 +412,35 @@ class QiitaClientTests(PluginTestCase):
         self.tester._plugincoupling = 'https'
         prefix = join(expanduser("~"), 'kurt')
         self.clean_up_files.append(prefix + fp)
+        print("STEFAN", fp, prefix)
         fp_obs = self.tester.fetch_file_from_central(fp, prefix=prefix)
+        print("STEFAN2", fp_obs)
         self.assertEqual(prefix + fp, fp_obs)
         self.assertTrue(filecmp.cmp(fp, fp_obs, shallow=False))
 
-    def test_push_file_to_central(self):
-        self.tester._plugincoupling = 'filesystem'
+    # def test_push_file_to_central(self):
+    #     self.tester._plugincoupling = 'filesystem'
 
-        ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
-        fp = ainfo['files']['raw_forward_seqs'][0]['filepath']
+    #     ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
+    #     fp = ainfo['files']['raw_forward_seqs'][0]['filepath']
 
-        # mode: filesystem
-        fp_obs = self.tester.push_file_to_central(fp)
-        self.assertEqual(fp, fp_obs)
+    #     # mode: filesystem
+    #     fp_obs = self.tester.push_file_to_central(fp)
+    #     self.assertEqual(fp, fp_obs)
 
-        # non existing mode
-        with self.assertRaises(ValueError):
-            self.tester._plugincoupling = 'foo'
-            self.tester.push_file_to_central(fp)
+    #     # non existing mode
+    #     with self.assertRaises(ValueError):
+    #         self.tester._plugincoupling = 'foo'
+    #         self.tester.push_file_to_central(fp)
 
-        # change transfer mode to https
-        self.tester._plugincoupling = 'https'
-        fp_source = 'foo.bar'
-        with open(fp_source, 'w') as f:
-            f.write("this is a test\n")
-        self.clean_up_files.append(fp_source)
-        fp_obs = self.tester.push_file_to_central(fp_source)
-        self.assertEqual(fp_source, fp_obs)
+    #     # change transfer mode to https
+    #     self.tester._plugincoupling = 'https'
+    #     fp_source = 'foo.bar'
+    #     with open(fp_source, 'w') as f:
+    #         f.write("this is a test\n")
+    #     self.clean_up_files.append(fp_source)
+    #     fp_obs = self.tester.push_file_to_central(fp_source)
+    #     self.assertEqual(fp_source, fp_obs)
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -408,6 +408,14 @@ class QiitaClientTests(PluginTestCase):
             self.tester._plugincoupling = 'foo'
             self.tester.fetch_file_from_central(fp)
 
+        # change transfer mode to https
+        self.tester._plugincoupling = 'https'
+        prefix = join(expanduser("~"), 'kurt')
+        self.clean_up_files.append(prefix + fp)
+        fp_obs = self.tester.fetch_file_from_central(fp, prefix=prefix)
+        self.assertEqual(prefix + fp, fp_obs)
+        self.assertTrue(filecmp.cmp(fp, fp_obs, shallow=False))
+
     def test_push_file_to_central(self):
         self.tester._plugincoupling = 'filesystem'
 
@@ -422,6 +430,15 @@ class QiitaClientTests(PluginTestCase):
         with self.assertRaises(ValueError):
             self.tester._plugincoupling = 'foo'
             self.tester.push_file_to_central(fp)
+
+        # change transfer mode to https
+        self.tester._plugincoupling = 'https'
+        fp_source = 'foo.bar'
+        with open(fp_source, 'w') as f:
+            f.write("this is a test\n")
+        self.clean_up_files.append(fp_source)
+        fp_obs = self.tester.push_file_to_central(fp_source)
+        self.assertEqual(fp_source, fp_obs)
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -9,7 +9,7 @@
 from unittest import TestCase, main
 import filecmp
 from os import remove, close
-from os.path import basename, exists
+from os.path import basename, exists, expanduser, join
 from tempfile import mkstemp
 from json import dumps
 import pandas as pd
@@ -397,9 +397,10 @@ class QiitaClientTests(PluginTestCase):
         self.assertEqual(fp, fp_obs)
 
         # mode: filesystem, prefix='/karl': make file copy
-        self.clean_up_files.append('/karl' + fp)
-        fp_obs = self.tester.fetch_file_from_central(fp, prefix='/karl')
-        self.assertEqual('/karl' + fp, fp_obs)
+        prefix = join(expanduser("~"), '/karl')
+        self.clean_up_files.append(prefix + fp)
+        fp_obs = self.tester.fetch_file_from_central(fp, prefix=prefix)
+        self.assertEqual(prefix + fp, fp_obs)
         self.assertTrue(filecmp.cmp(fp, fp_obs, shallow=False))
 
         # non existing mode


### PR DESCRIPTION
This is the companion PR to https://github.com/qiita-spots/qiita/pull/3480 where the heavy lifting is implemented to transfer files between qiita main and plugins via a) "filesystem", i.e. direct access as is or b) via "https" get and post tornado methods. In the feature we can extend by S3 or other protocols.

I want to re-use the existing `_request_retry` mechanism, but didn't know how to return the binary content in https://github.com/jlab/qiita_client/blob/c2d597647b3a22792a7dcd88408895e81d33ceb6/qiita_client/qiita_client.py#L394 without adding the new "rettype" parameter. Is there an easier way?