### PR TITLE
change plugin coupling protocol for tests

### DIFF
--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -53,8 +53,10 @@ jobs:
           # we need to download qiita directly so we have "easy" access to
           # all config files
           # wget https://github.com/biocore/qiita/archive/dev.zip
-          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler.zip -O dev.zip
-          unzip dev.zip
+          # unzip dev.zip
+          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler.zip
+          unzip tornado_FetchFileFromCentralHandler.zip
+          mv qiita-tornado_FetchFileFromCentralHandler qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -104,7 +104,9 @@ jobs:
           mkdir -p ${CONDA_PREFIX}/var/run/nginx/
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
-          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          echo "error_log /home/runner/logs/nginx_error.log debug;" > ${NGINX_FILE_NEW}
+          echo "access_log /home/runner/logs/nginx_access.log debug;" >> ${NGINX_FILE_NEW}
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} >> ${NGINX_FILE_NEW}
           sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
           nginx -V >&2
           nginx -c ${NGINX_FILE_NEW}
@@ -128,7 +130,9 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           export QIITA_CLIENT_DEBUG_LEVEL=DEBUG
-          nosetests --with-doctest --with-coverage --cover-package=qiita_client
+          nosetests --with-doctest --with-coverage --cover-package=qiita_client; true
+          cat /home/runner/logs/nginx_error.log
+          cat /home/runner/logs/nginx_access.log
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -54,9 +54,9 @@ jobs:
           # all config files
           # wget https://github.com/biocore/qiita/archive/dev.zip
           # unzip dev.zip
-          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler_alsoDirs_debug.zip
-          unzip tornado_FetchFileFromCentralHandler_alsoDirs_debug.zip
-          mv qiita-tornado_FetchFileFromCentralHandler_alsoDirs_debug qiita-dev
+          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler.zip
+          unzip tornado_FetchFileFromCentralHandler.zip
+          mv qiita-tornado_FetchFileFromCentralHandler qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -52,7 +52,8 @@ jobs:
 
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          wget https://github.com/biocore/qiita/archive/dev.zip
+          # wget https://github.com/biocore/qiita/archive/dev.zip
+          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler.zip -O dev.zip
           unzip dev.zip
 
           # pull out the port so we can modify the configuration file easily
@@ -105,7 +106,6 @@ jobs:
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           echo "error_log /home/runner/logs/nginx_error.log debug;" > ${NGINX_FILE_NEW}
-          echo "access_log /home/runner/logs/nginx_access.log debug;" >> ${NGINX_FILE_NEW}
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} >> ${NGINX_FILE_NEW}
           sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
           nginx -V >&2

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -107,11 +107,8 @@ jobs:
           mkdir -p ${CONDA_PREFIX}/var/run/nginx/
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
-          mkdir -p /home/runner/logs/
-          echo "error_log /home/runner/logs/nginx_error.log debug;" > ${NGINX_FILE_NEW}
-          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} >> ${NGINX_FILE_NEW}
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
           sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
-          nginx -V >&2
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"
@@ -133,9 +130,7 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           export QIITA_CLIENT_DEBUG_LEVEL=DEBUG
-          nosetests --with-doctest --with-coverage --cover-package=qiita_client; true
-          cat /home/runner/logs/nginx_error.log
-          cat /home/runner/logs/nginx_access.log
+          nosetests --with-doctest --with-coverage --cover-package=qiita_client
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -107,6 +107,7 @@ jobs:
           mkdir -p ${CONDA_PREFIX}/var/run/nginx/
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
+          mkdir -p /home/runner/logs/
           echo "error_log /home/runner/logs/nginx_error.log debug;" > ${NGINX_FILE_NEW}
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} >> ${NGINX_FILE_NEW}
           sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -130,8 +130,7 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           export QIITA_CLIENT_DEBUG_LEVEL=DEBUG
-          nosetests --with-doctest --with-coverage --cover-package=qiita_client; true
-          cat /tmp/stefan.log
+          nosetests --with-doctest --with-coverage --cover-package=qiita_client; cat /tmp/stefan.log
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -106,6 +106,7 @@ jobs:
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
           sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
+          nginx -V >&2
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -54,9 +54,9 @@ jobs:
           # all config files
           # wget https://github.com/biocore/qiita/archive/dev.zip
           # unzip dev.zip
-          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler.zip
-          unzip tornado_FetchFileFromCentralHandler.zip
-          mv qiita-tornado_FetchFileFromCentralHandler qiita-dev
+          wget https://github.com/jlab/qiita/archive/refs/heads/tornado_FetchFileFromCentralHandler_alsoDirs_debug.zip
+          unzip tornado_FetchFileFromCentralHandler_alsoDirs_debug.zip
+          mv qiita-tornado_FetchFileFromCentralHandler_alsoDirs_debug qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}
@@ -130,7 +130,8 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           export QIITA_CLIENT_DEBUG_LEVEL=DEBUG
-          nosetests --with-doctest --with-coverage --cover-package=qiita_client
+          nosetests --with-doctest --with-coverage --cover-package=qiita_client; true
+          cat /tmp/stefan.log
 
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -130,7 +130,7 @@ jobs:
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
           export QIITA_CLIENT_DEBUG_LEVEL=DEBUG
-          nosetests --with-doctest --with-coverage --cover-package=qiita_client; cat /tmp/stefan.log
+          nosetests --with-doctest --with-coverage --cover-package=qiita_client
 
       - uses: codecov/codecov-action@v3
         with:

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -137,10 +137,17 @@ class QiitaCommand(object):
 
     def __call__(self, qclient, server_url, job_id, output_dir):
         logger.debug('Entered QiitaCommand.__call__()')
-        status, artifacts, error_message = self.function(
+        results = self.function(
             qclient, server_url, job_id, output_dir)
-        return status, QiitaCommand._push_artifacts_files_to_central(
-            qclient, artifacts), error_message
+        # typical, but not all, functions of QiitaCommands return 3-tuple
+        # status=bool, list of artifacts, error_message=str
+        if isinstance(results, tuple) and (len(results) == 3) and \
+           isinstance(results[0], bool) and \
+           isinstance(results[1], list) and \
+           isinstance(results[2], str):
+            results[1] = QiitaCommand._push_artifacts_files_to_central(
+                qclient, results[1])
+        return results
 
 
 class QiitaArtifactType(object):

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -15,7 +15,7 @@ from os import makedirs, environ
 from future import standard_library
 from json import dumps
 import urllib
-from qiita_client import QiitaClient
+from qiita_client import QiitaClient, ArtifactInfo
 
 import logging
 
@@ -118,22 +118,13 @@ class QiitaCommand(object):
             return artifacts
 
         for artifact in artifacts:
-            if artifact is not None:
-                if 'files' in artifact.keys():
-                    artifact['files'] = {
-                        filetype: [
-                            {
-                                k: qclient.push_file_to_central(v)
-                                if k == 'filepath' else v
-                                for k, v
-                                in file.items()}
-                            for file
-                            in artifact['files'][filetype]]
-                        for filetype
-                        in artifact['files'].keys()
-                    }
-
-        return artifacts
+            if isinstance(artifact, ArtifactInfo):
+                for i in range(len(artifact.files)):
+                    (fp, ftype) = artifact.files[i]
+                    # send file to Qiita central and potentially update
+                    # filepath, which is not done at the moment (2025-11-14)
+                    fp = qclient.push_file_to_central(fp)
+                    artifact.files[i] = (fp, ftype)
 
     def __call__(self, qclient, server_url, job_id, output_dir):
         logger.debug('Entered QiitaCommand.__call__()')

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -120,10 +120,13 @@ class QiitaCommand(object):
 
         for artifact in artifacts:
             if isinstance(artifact, ArtifactInfo):
+                logger.debug('QiitaCommand::__call__: Push artifact files '
+                             'via %s to central:' % qclient._plugincoupling)
                 for i in range(len(artifact.files)):
                     (fp, ftype) = artifact.files[i]
                     # send file to Qiita central and potentially update
                     # filepath, which is not done at the moment (2025-11-14)
+                    logger.debug('  artifact files %s pushed to central' % fp)
                     fp = qclient.push_file_to_central(fp)
                     artifact.files[i] = (fp, ftype)
 

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -100,6 +100,7 @@ class QiitaCommand(object):
         self.outputs = outputs
         self.analysis_only = analysis_only
 
+    @staticmethod
     def _push_artifacts_files_to_central(qclient, artifacts):
         """Pushes all files of a list of artifacts to BASE_DATA_DIR.
 
@@ -136,8 +137,7 @@ class QiitaCommand(object):
            isinstance(results[0], bool) and \
            isinstance(results[1], list) and \
            isinstance(results[2], str):
-            results[1] = QiitaCommand._push_artifacts_files_to_central(
-                qclient, results[1])
+            QiitaCommand._push_artifacts_files_to_central(qclient, results[1])
         return results
 
 

--- a/qiita_client/plugin.py
+++ b/qiita_client/plugin.py
@@ -100,9 +100,47 @@ class QiitaCommand(object):
         self.outputs = outputs
         self.analysis_only = analysis_only
 
+    def _push_artifacts_files_to_central(qclient, artifacts):
+        """Pushes all files of a list of artifacts to BASE_DATA_DIR.
+
+        Parameters
+        ----------
+        qclient : qiita_client.QiitaClient
+            The Qiita server client
+        artifacts : [ArtifactInfo]
+            A list of qiita Artifacts
+
+        Returns
+        -------
+        The input list of artifacts
+        """
+        if artifacts is None:
+            return artifacts
+
+        for artifact in artifacts:
+            if artifact is not None:
+                if 'files' in artifact.keys():
+                    artifact['files'] = {
+                        filetype: [
+                            {
+                                k: qclient.push_file_to_central(v)
+                                if k == 'filepath' else v
+                                for k, v
+                                in file.items()}
+                            for file
+                            in artifact['files'][filetype]]
+                        for filetype
+                        in artifact['files'].keys()
+                    }
+
+        return artifacts
+
     def __call__(self, qclient, server_url, job_id, output_dir):
         logger.debug('Entered QiitaCommand.__call__()')
-        return self.function(qclient, server_url, job_id, output_dir)
+        status, artifacts, error_message = self.function(
+            qclient, server_url, job_id, output_dir)
+        return status, QiitaCommand._push_artifacts_files_to_central(
+            qclient, artifacts), error_message
 
 
 class QiitaArtifactType(object):

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -17,6 +17,7 @@ from random import randint
 import fnmatch
 from io import BytesIO
 from zipfile import ZipFile
+import re
 
 
 try:
@@ -412,6 +413,38 @@ class QiitaClient(object):
             "Request '%s %s' did not succeed. Status code: %d. Message: %s"
             % (req.__name__, url, r.status_code, r.text))
 
+    def _fetch_artifact_files(self, ainfo):
+        """helper method to fetch all files of an artifact from Qiita main.
+
+        Parameters
+        ----------
+        ainfo : json dict
+            Information about Qiita artifact
+
+        Returns
+        -------
+        Same as input BUT filepaths are adapated after downloading files from
+        Qiita main to local IF protocol coupling != filesystem. Otherwise, no
+        change occurs.
+        """
+        if self._plugincoupling != 'filesystem':
+            if 'files' in ainfo.keys():
+                ainfo['files'] = {
+                    filetype: [
+                        {
+                            k: self.fetch_file_from_central(v)
+                            if k == 'filepath' else v
+                            for k, v
+                            in file.items()}
+                        for file
+                        in ainfo['files'][filetype]]
+                    for filetype
+                    in ainfo['files'].keys()
+                }
+            return ainfo
+        else:
+            return ainfo
+
     def get(self, url, rettype='json', **kwargs):
         """Execute a get request against the Qiita server
 
@@ -431,8 +464,27 @@ class QiitaClient(object):
             The JSON response from the server
         """
         logger.debug('Entered QiitaClient.get()')
-        return self._request_retry(
+        result = self._request_retry(
             self._session.get, url, rettype=rettype, **kwargs)
+
+        if self._plugincoupling != 'filesystem':
+            # intercept get requests from plugins that request metadata or
+            # artifact files and ensure they get transferred from Qiita
+            # central, when not using "filesystem"
+            if re.search(r"/qiita_db/prep_template/\d+/?$", url):
+                # client is requesting filepath to a prep/metadata file, see
+                # qiita/qiita_db/handlers/prep_template.py::
+                #   PrepTemplateDBHandler::get
+                # for the "result" data-structure
+                for fp in ['prep-file', 'sample-file']:
+                    result[fp] = self.fetch_file_from_central(result[fp])
+            elif re.search(r"/qiita_db/artifacts/\d+/?$", url):
+                # client is requesting an artifact, see
+                # qiita/qiita_db/handlers/artifact.py::ArtifactHandler::get
+                # for the "result" data-structure
+                result = self._fetch_artifact_files(result)
+
+        return result
 
     def post(self, url, **kwargs):
         """Execute a post request against the Qiita server

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -919,10 +919,11 @@ class QiitaClient(object):
         The given filepath - to be transparent in plugin code.
         """
         if self._plugincoupling == 'filesystem':
-            if os.path.isdir(filepath):
-                shutil.rmtree(filepath)
-            else:
-                os.remove(filepath)
+            if os.path.exists(filepath):
+                if os.path.isdir(filepath):
+                    shutil.rmtree(filepath)
+                else:
+                    os.remove(filepath)
         elif self._plugincoupling == 'https':
             # will return in internal server error, when qiita is in productive
             # mode

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -784,7 +784,8 @@ class QiitaClient(object):
         if self._plugincoupling == 'filesystem':
             if (prefix is not None) and (prefix != ""):
                 # create necessary directory locally
-                os.makedirs(os.path.dirname(target_filepath), exist_ok=True)
+                if not os.path.exists(os.path.dirname(target_filepath)):
+                    os.makedirs(os.path.dirname(target_filepath))
 
                 shutil.copyfile(filepath, target_filepath)
 
@@ -803,7 +804,8 @@ class QiitaClient(object):
                 rettype='content')
 
             # create necessary directory locally
-            os.makedirs(os.path.dirname(target_filepath), exist_ok=True)
+            if not os.path.exists(os.path.dirname(target_filepath)):
+                os.makedirs(os.path.dirname(target_filepath))
 
             # write retrieved file content
             with open(target_filepath, 'wb') as f:

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -897,10 +897,13 @@ class QiitaClient(object):
     def delete_file_from_central(self, filepath):
         """Deletes a file in Qiita's central BASE_DATA_DIR directory.
 
-        I currently (2025-09-25) assess this operation to be too dangerous for
+        I currently (2025-11-12) assess this operation to be too dangerous for
         protocols other than "filesystem", i.e. on "https" the files are NOT
         deleted.
-        However, this might change in the future and since I don't want to
+        However, in plugin tests, this function is needed and I therefore
+        implemented an API endpoint which is only activated when Qiita main
+        instance is operated in test mode.
+        This might change in the future and since I don't want to
         touch every plugin's code again, I am adding this function here already
         and use it in according plugin code locations, e.g. function _gzip_file
         in qtp-sequencing.
@@ -916,8 +919,16 @@ class QiitaClient(object):
         The given filepath - to be transparent in plugin code.
         """
         if self._plugincoupling == 'filesystem':
-            os.remove(filepath)
+            if os.path.isdir(filepath):
+                shutil.rmtree(filepath)
+            else:
+                os.remove(filepath)
         elif self._plugincoupling == 'https':
-            pass
+            try:
+                response = self.get(
+                    '/cloud/delete_file_from_central/' + filepath,
+                    rettype='object')
+            except:
+                pass
 
         return filepath

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -863,8 +863,9 @@ class QiitaClient(object):
             return filepath
 
         elif self._plugincoupling == 'https':
-            logger.debug('Submitting %s %s to qiita server.' % (
-                'directory' if os.path.isdir(filepath) else 'file', filepath))
+            logger.debug('Submitting %s %s to qiita server via %s' % (
+                'directory' if os.path.isdir(filepath) else 'file', filepath,
+                self._plugincoupling))
 
             # target path, i.e. without filename
             dirpath = os.path.dirname(filepath)

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -790,6 +790,10 @@ class QiitaClient(object):
 
                 shutil.copyfile(filepath, target_filepath)
 
+            logger.debug(
+                'Fetching file "%s" via protocol=%s from Qiita main.' % (
+                    filepath, self._plugincoupling))
+
             return target_filepath
 
         elif self._plugincoupling == 'https':
@@ -812,6 +816,10 @@ class QiitaClient(object):
             with open(target_filepath, 'wb') as f:
                 f.write(content)
 
+            logger.debug(
+                'Fetching file "%s" via protocol=%s from Qiita main.' % (
+                    filepath, self._plugincoupling))
+
             return target_filepath
 
         else:
@@ -820,7 +828,7 @@ class QiitaClient(object):
                  "configuration is NOT defined.") % self._plugincoupling)
 
     def push_file_to_central(self, filepath):
-        """Pushs file- or directory content  to Qiita's central BASE_DATA_DIR
+        """Pushs file- or directory content to Qiita's central BASE_DATA_DIR
            directory.
 
         By default, plugin and Qiita's central BASE_DATA_DIR filesystems are

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -881,6 +881,7 @@ class QiitaClient(object):
                 for root, dirnames, filenames in os.walk(filepath):
                     for filename in fnmatch.filter(filenames, "*"):
                         fp = os.path.join(root, filename)
+                        print("äääääääääää '%s' '%s' '%s' '%s' " % (root, dirnames, filenames, os.path.join(dirpath, os.path.dirname(fp))))
                         self.post('/cloud/push_file_to_central/',
                                   files={os.path.join(
                                       dirpath,

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -15,6 +15,9 @@ import pandas as pd
 from json import dumps
 from random import randint
 import fnmatch
+from io import BytesIO
+from zipfile import ZipFile
+
 
 try:
     from itertools import zip_longest
@@ -269,7 +272,7 @@ class QiitaClient(object):
             The request to execute
         rettype : string
             The return type of the function, either "json" or
-            if e.g. files are transferred "content"
+            "object" for the response object itself
         args : tuple
             The request args
         kwargs : dict
@@ -328,7 +331,7 @@ class QiitaClient(object):
             The request to execute
         rettype : string
             The return type of the function, either "json" (default) or
-            if e.g. files are transferred "content"
+            "object" for the response object itself
         url : str
             The url to access in the server
         kwargs : dict
@@ -336,7 +339,7 @@ class QiitaClient(object):
 
         Returns
         -------
-        dict or None or plain content IF rettype='content'
+        dict or None or response object IF rettype='object'
             The JSON information in the request response, if any
 
         Raises
@@ -391,13 +394,13 @@ class QiitaClient(object):
                     if rettype is None or rettype == 'json':
                         return r.json()
                     else:
-                        if rettype == 'content':
-                            return r.content
+                        if rettype == 'object':
+                            return r
                         else:
                             raise ValueError(
                                 ("return type rettype='%s' cannot be "
                                  "understand. Choose from 'json' (default) "
-                                 "or 'content!") % rettype)
+                                 "or 'object!") % rettype)
                 except ValueError:
                     return None
             stime = randint(MIN_TIME_SLEEP, MAX_TIME_SLEEP)
@@ -418,7 +421,7 @@ class QiitaClient(object):
             The url to access in the server
         rettype : string
             The return type of the function, either "json" (default) or
-            if e.g. files are transferred "content"
+            "object" for the response object itself
         kwargs : dict
             The request kwargs
 
@@ -746,8 +749,8 @@ class QiitaClient(object):
         return sample_names, prep_info
 
     def fetch_file_from_central(self, filepath, prefix=None):
-        """Moves content of a file from Qiita's central BASE_DATA_DIR to a
-           local plugin file-system.
+        """Moves content of a file or directory from Qiita's central
+           BASE_DATA_DIR to a local plugin file-system.
 
            By default, this is exactly the same location, i.e. the return
            filepath is identical to the requested one and nothing is moved /
@@ -760,22 +763,24 @@ class QiitaClient(object):
         ----------
         filepath : str
             The filepath in Qiita's central BASE_DATA_DIR to the requested
-            file content
+            file or directory content
         prefix : str
             Primarily for testing: prefix the target filepath with this
             filepath prefix to
-            a) in 'filesystem' mode: create an actual file copy (for testing)
+            a) in 'filesystem' mode: create an actual file/directiry copy
+               (for testing)
                If prefix=None, nothing will be copied/moved
-            b) in 'https' mode: flexibility to locate files differently in
-               plugin local file system.
+            b) in 'https' mode: flexibility to locate files/directories
+               differently in plugin local file system.
 
         Returns
         -------
-        str : the filepath of the requested file within the local file system
+        str : the filepath of the requested file or directory within the local
+              file system
         """
         target_filepath = filepath
         logger.debug(
-            'Fetching file "%s" via protocol=%s from Qiita main.' % (
+            'Fetching file/directory "%s" via protocol=%s from Qiita main.' % (
                 filepath, self._plugincoupling))
 
         if (prefix is not None) and (prefix != ""):
@@ -792,7 +797,10 @@ class QiitaClient(object):
                 if not os.path.exists(os.path.dirname(target_filepath)):
                     os.makedirs(os.path.dirname(target_filepath))
 
-                shutil.copyfile(filepath, target_filepath)
+                if os.path.isdir(filepath):
+                    shutil.copytree(filepath, target_filepath)
+                else:
+                    shutil.copyfile(filepath, target_filepath)
 
             return target_filepath
 
@@ -802,17 +810,24 @@ class QiitaClient(object):
                 filepath = filepath[len(os.path.abspath(os.sep)):]
 
             # actual call to Qiita central to obtain file content
-            content = self.get(
+            response = self.get(
                 '/cloud/fetch_file_from_central/' + filepath,
-                rettype='content')
+                rettype='object')
 
-            # create necessary directory locally
-            if not os.path.exists(os.path.dirname(target_filepath)):
-                os.makedirs(os.path.dirname(target_filepath))
+            # check if requested filepath is a single file OR a whole directory
+            if 'Is-Qiita-Directory' in response.headers.keys():
+                with ZipFile(BytesIO(response.content)) as zf:
+                    zf.extractall(path=target_filepath)
+            else:
+                content = response.content
 
-            # write retrieved file content
-            with open(target_filepath, 'wb') as f:
-                f.write(content)
+                # create necessary directory locally
+                if not os.path.exists(os.path.dirname(target_filepath)):
+                    os.makedirs(os.path.dirname(target_filepath))
+
+                # write retrieved file content
+                with open(target_filepath, 'wb') as f:
+                    f.write(content)
 
             return target_filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -817,6 +817,9 @@ class QiitaClient(object):
             # check if requested filepath is a single file OR a whole directory
             if 'Is-Qiita-Directory' in response.headers.keys():
                 with ZipFile(BytesIO(response.content)) as zf:
+                    import sys
+                    print("ÖÖÖÖÖ in client:\n%s" % zf.filelist, file=sys.stderr)
+
                     zf.extractall(path=target_filepath)
             else:
                 content = response.content

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -820,20 +820,23 @@ class QiitaClient(object):
                  "configuration is NOT defined.") % self._plugincoupling)
 
     def push_file_to_central(self, filepath):
-        """Pushs filecontent to Qiita's central BASE_DATA_DIR directory.
+        """Pushs file- or directory content  to Qiita's central BASE_DATA_DIR
+           directory.
 
         By default, plugin and Qiita's central BASE_DATA_DIR filesystems are
         identical. In this case, no files are touched and the filepath is
         directly returned.
         If however, plugincoupling is set to 'https', the content of the file
-        is sent via https POST to Qiita's master/worker, which has to receive
-        and store in an appropriate location.
+        (or content of recursively all files in the given directory) is sent
+        via https POST to Qiita's master/worker, which has to receive and store
+        in an appropriate location.
 
         Parameters
         ----------
         filepath : str
-            The filepath of the files whos content shall be send to Qiita's
-            central BASE_DATA_DIR
+            The filepath of the file(s) whos content shall be send to Qiita's
+            central BASE_DATA_DIR.
+            Can be a path to a directory as well.
 
         Returns
         -------
@@ -872,3 +875,31 @@ class QiitaClient(object):
         raise ValueError(
             ("File communication protocol '%s' as defined in plugins "
              "configuration is NOT defined.") % self._plugincoupling)
+
+    def delete_file_from_central(self, filepath):
+        """Deletes a file in Qiita's central BASE_DATA_DIR directory.
+
+        I currently (2025-09-25) assess this operation to be too dangerous for
+        protocols other than "filesystem", i.e. on "https" the files are NOT
+        deleted.
+        However, this might change in the future and since I don't want to
+        touch every plugin's code again, I am adding this function here already
+        and use it in according plugin code locations, e.g. function _gzip_file
+        in qtp-sequencing.
+
+        Parameters
+        ----------
+        filepath : str
+            The filepath of the file that shall be deletes in Qiita's
+            central BASE_DATA_DIR
+
+        Returns
+        -------
+        The given filepath - to be transparent in plugin code.
+        """
+        if self._plugincoupling == 'filesystem':
+            os.remove(filepath)
+        elif self._plugincoupling == 'https':
+            pass
+
+        return filepath

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -14,6 +14,7 @@ import threading
 import pandas as pd
 from json import dumps
 from random import randint
+import fnmatch
 
 try:
     from itertools import zip_longest
@@ -842,16 +843,29 @@ class QiitaClient(object):
             return filepath
 
         elif self._plugincoupling == 'https':
-            logger.debug('Submitting file %s to qiita server.' % filepath)
+            logger.debug('Submitting %s %s to qiita server.' % (
+                'directory' if os.path.isdir(filepath) else 'file', filepath))
 
             # target path, i.e. without filename
             dirpath = os.path.dirname(filepath)
             if dirpath == "":
                 dirpath = "/"
 
-            self.post(
-                '/cloud/push_file_to_central/',
-                files={dirpath: open(filepath, 'rb')})
+            if os.path.isdir(filepath):
+                # Pushing all files of a directory, not only a single file.
+                # Cannot use "glob" as it lacks the "recursive" parameter in
+                # py27. This is used e.g. in qp-target-gene
+                for root, dirnames, filenames in os.walk(filepath):
+                    for filename in fnmatch.filter(filenames, "*"):
+                        fp = os.path.join(root, filename)
+                        self.post('/cloud/push_file_to_central/',
+                                  files={os.path.join(
+                                      dirpath,
+                                      os.path.dirname(fp)): open(fp, 'rb')})
+            else:
+                self.post(
+                    '/cloud/push_file_to_central/',
+                    files={dirpath: open(filepath, 'rb')})
 
             return filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -817,9 +817,6 @@ class QiitaClient(object):
             # check if requested filepath is a single file OR a whole directory
             if 'Is-Qiita-Directory' in response.headers.keys():
                 with ZipFile(BytesIO(response.content)) as zf:
-                    import sys
-                    print("ÖÖÖÖÖ in client:\n%s" % zf.filelist, file=sys.stderr)
-
                     zf.extractall(path=target_filepath)
             else:
                 content = response.content
@@ -881,7 +878,6 @@ class QiitaClient(object):
                 for root, dirnames, filenames in os.walk(filepath):
                     for filename in fnmatch.filter(filenames, "*"):
                         fp = os.path.join(root, filename)
-                        print("äääääääääää '%s' '%s' '%s' '%s' " % (root, dirnames, filenames, os.path.join(dirpath, os.path.dirname(fp))))
                         self.post('/cloud/push_file_to_central/',
                                   files={os.path.join(
                                       dirpath,

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -926,7 +926,7 @@ class QiitaClient(object):
         elif self._plugincoupling == 'https':
             # will return in internal server error, when qiita is in productive
             # mode
-            response = self.get(
+            self.get(
                 '/cloud/delete_file_from_central/' + filepath,
                 rettype='object')
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -428,6 +428,8 @@ class QiitaClient(object):
         change occurs.
         """
         if self._plugincoupling != 'filesystem':
+            logger.debug('QiitaClient::get: fetching artfiact file from '
+                         'central: %s' % ainfo['files'])
             if 'files' in ainfo.keys():
                 ainfo['files'] = {
                     filetype: [
@@ -476,7 +478,10 @@ class QiitaClient(object):
                 # qiita/qiita_db/handlers/prep_template.py::
                 #   PrepTemplateDBHandler::get
                 # for the "result" data-structure
+                logger.debug('QiitaClient::get: fetching artifact metadata'
+                             '-file from central:')
                 for fp in ['prep-file', 'sample-file']:
+                    logger.debug('QiitaClient::get:   file %s' % result[fp])
                     result[fp] = self.fetch_file_from_central(result[fp])
             elif re.search(r"/qiita_db/artifacts/\d+/?$", url):
                 # client is requesting an artifact, see

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -774,6 +774,10 @@ class QiitaClient(object):
         str : the filepath of the requested file within the local file system
         """
         target_filepath = filepath
+        logger.debug(
+            'Fetching file "%s" via protocol=%s from Qiita main.' % (
+                filepath, self._plugincoupling))
+
         if (prefix is not None) and (prefix != ""):
             # strip off root
             if filepath.startswith(os.path.abspath(os.sep)):
@@ -790,18 +794,12 @@ class QiitaClient(object):
 
                 shutil.copyfile(filepath, target_filepath)
 
-            logger.debug(
-                'Fetching file "%s" via protocol=%s from Qiita main.' % (
-                    filepath, self._plugincoupling))
-
             return target_filepath
 
         elif self._plugincoupling == 'https':
             # strip off root
             if filepath.startswith(os.path.abspath(os.sep)):
                 filepath = filepath[len(os.path.abspath(os.sep)):]
-
-            logger.debug('Requesting file %s from qiita server.' % filepath)
 
             # actual call to Qiita central to obtain file content
             content = self.get(
@@ -815,10 +813,6 @@ class QiitaClient(object):
             # write retrieved file content
             with open(target_filepath, 'wb') as f:
                 f.write(content)
-
-            logger.debug(
-                'Fetching file "%s" via protocol=%s from Qiita main.' % (
-                    filepath, self._plugincoupling))
 
             return target_filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -924,11 +924,10 @@ class QiitaClient(object):
             else:
                 os.remove(filepath)
         elif self._plugincoupling == 'https':
-            try:
-                response = self.get(
-                    '/cloud/delete_file_from_central/' + filepath,
-                    rettype='object')
-            except:
-                pass
+            # will return in internal server error, when qiita is in productive
+            # mode
+            response = self.get(
+                '/cloud/delete_file_from_central/' + filepath,
+                rettype='object')
 
         return filepath

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -11,7 +11,7 @@ from os import environ
 from time import sleep
 
 from qiita_client import QiitaClient
-from qiita_client.plugin import BaseQiitaPlugin
+from .plugin import BaseQiitaPlugin
 
 import logging
 

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -7,7 +7,8 @@
 # -----------------------------------------------------------------------------
 
 from unittest import TestCase
-from os import environ
+from os import environ, sep
+from os.path import isabs, join, exists
 from time import sleep
 
 from qiita_client import QiitaClient
@@ -82,3 +83,30 @@ class PluginTestCase(TestCase):
                 break
 
         return status
+
+    def _fix_plugincoupling_filepath(self, fp, BASE_DATA_DIR="/qiita_data/"):
+        # In some plugin tests, example files are generated temporarily on
+        # local tmp directories. This is fine for plugincoupling == filesystem
+        # but will cause "File not found errors" when communication through
+        # other protocols as the file actually has never been pushed to Qiita
+        # main. This helper function shall fix this by copying the according
+        # files over to Qiita main WHEN not using "filesystem" and fix the
+        # according file paths, i.e. we need to prepend the BASE_DATA_DIR to
+        # the filename, which should be '/qiita_data/' e.g. here
+        # https://github.com/jlab/qiita-keycloak
+        if not exists(fp):
+            raise ValueError("Filepath does not exist!")
+
+        if self.qclient._plugincoupling == 'filesystem':
+            return fp
+        else:
+            processed_fp = fp
+            # chop off leading / for join to work properly when prepending
+            # the BASE_DATA_DIR
+            if isabs(processed_fp):
+                processed_fp = processed_fp[len(sep):]
+            processed_fp = join(BASE_DATA_DIR, processed_fp)
+            # ensure file is transferred to qiita main
+            self.qclient.push_file_to_central(fp)
+            # return the filepath prepended with qiita main base_data_dir
+            return processed_fp

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -10,7 +10,8 @@ from unittest import TestCase
 from os import environ
 from time import sleep
 
-from qiita_client import QiitaClient, BaseQiitaPlugin
+from qiita_client import QiitaClient
+from qiita_client.plugin import BaseQiitaPlugin
 
 import logging
 

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -87,8 +87,8 @@ class PluginTestCase(TestCase):
     def deposite_in_qiita_basedir(self, fps, update_fp_only=False):
         """Pushs a file to qiita main AND adapts given filepath accordingly.
 
-        A helper function to fix file paths in tests such that they point to the
-        expected BASE_DATA_DIR. This becomes necessary when uncoupling the
+        A helper function to fix file paths in tests such that they point to
+        the expected BASE_DATA_DIR. This becomes necessary when uncoupling the
         plugin filesystem as some methods now actually fetches expected files
         from BASE_DATA_DIR. This will fail for protocols other than filesystem
         IF files are created locally by the plugin test.
@@ -99,8 +99,8 @@ class PluginTestCase(TestCase):
             Filepath or list of filepaths to file(s) that shall be part of
             BASE_DATA_DIR, but currently points to some tmp file for testing.
         update_fp_only : bool
-            Some tests operate on filepaths only - files do not actually need to
-            exist. Thus, we don't need to tranfer a file.
+            Some tests operate on filepaths only - files do not actually need
+            to exist. Thus, we don't need to tranfer a file.
         """
         if self.qclient._plugincoupling == 'filesystem':
             return fps

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -10,8 +10,7 @@ from unittest import TestCase
 from os import environ
 from time import sleep
 
-from qiita_client import QiitaClient
-from plugin import BaseQiitaPlugin
+from qiita_client import QiitaClient, BaseQiitaPlugin
 
 import logging
 

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -8,7 +8,7 @@
 
 from unittest import TestCase
 from os import environ, sep
-from os.path import isabs, join, exists
+from os.path import join, relpath
 from time import sleep
 
 from qiita_client import QiitaClient
@@ -84,29 +84,46 @@ class PluginTestCase(TestCase):
 
         return status
 
-    def _fix_plugincoupling_filepath(self, fp, BASE_DATA_DIR="/qiita_data/"):
-        # In some plugin tests, example files are generated temporarily on
-        # local tmp directories. This is fine for plugincoupling == filesystem
-        # but will cause "File not found errors" when communication through
-        # other protocols as the file actually has never been pushed to Qiita
-        # main. This helper function shall fix this by copying the according
-        # files over to Qiita main WHEN not using "filesystem" and fix the
-        # according file paths, i.e. we need to prepend the BASE_DATA_DIR to
-        # the filename, which should be '/qiita_data/' e.g. here
-        # https://github.com/jlab/qiita-keycloak
-        if not exists(fp):
-            raise ValueError("Filepath does not exist!")
+    def deposite_in_qiita_basedir(self, fps, update_fp_only=False):
+        """Pushs a file to qiita main AND adapts given filepath accordingly.
 
+        A helper function to fix file paths in tests such that they point to the
+        expected BASE_DATA_DIR. This becomes necessary when uncoupling the
+        plugin filesystem as some methods now actually fetches expected files
+        from BASE_DATA_DIR. This will fail for protocols other than filesystem
+        IF files are created locally by the plugin test.
+
+        Parameters
+        ----------
+        fps : str or [str]
+            Filepath or list of filepaths to file(s) that shall be part of
+            BASE_DATA_DIR, but currently points to some tmp file for testing.
+        update_fp_only : bool
+            Some tests operate on filepaths only - files do not actually need to
+            exist. Thus, we don't need to tranfer a file.
+        """
         if self.qclient._plugincoupling == 'filesystem':
-            return fp
+            return fps
+
+        # use artifact 1 info to determine BASA_DATA_DIR, as we know that the
+        # filepath ends with ....raw_data/1_s_G1_L001_sequences.fastq.gz, thus
+        # BASE_DATA_DIR must be the prefix, e.g. /qiita_data/
+        # This might break IF file
+        #    qiita-spots/qiita/qiita_db/support_files/populate_test_db.sql
+        # changes.
+        ainfo = self.qclient.get('/qiita_db/artifacts/1/')
+        base_data_dir = ainfo['files']['raw_forward_seqs'][0]['filepath'][
+            :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
+        if isinstance(fps, str):
+            if not update_fp_only:
+                self.qclient.push_file_to_central(fps)
+            return join(base_data_dir, relpath(fps, sep))
+        elif isinstance(fps, list):
+            for fp in fps:
+                if not update_fp_only:
+                    self.qclient.push_file_to_central(fp)
+            return [join(base_data_dir, relpath(fp, sep)) for fp in fps]
         else:
-            processed_fp = fp
-            # chop off leading / for join to work properly when prepending
-            # the BASE_DATA_DIR
-            if isabs(processed_fp):
-                processed_fp = processed_fp[len(sep):]
-            processed_fp = join(BASE_DATA_DIR, processed_fp)
-            # ensure file is transferred to qiita main
-            self.qclient.push_file_to_central(fp)
-            # return the filepath prepended with qiita main base_data_dir
-            return processed_fp
+            raise ValueError(
+                "_deposite_in_qiita_basedir is not implemented for type %s"
+                % type(fps))

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -113,9 +113,6 @@ class PluginTestCase(TestCase):
                 return fp[len(sep):]
             return fp
 
-        if self.qclient._plugincoupling == 'filesystem':
-            return fps
-
         # use artifact 1 info to determine BASA_DATA_DIR, as we know that the
         # filepath ends with ....raw_data/1_s_G1_L001_sequences.fastq.gz, thus
         # BASE_DATA_DIR must be the prefix, e.g. /qiita_data/

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -8,7 +8,7 @@
 
 from unittest import TestCase
 from os import environ, sep
-from os.path import join, relpath
+from os.path import join, isabs
 from time import sleep
 
 from qiita_client import QiitaClient
@@ -101,7 +101,18 @@ class PluginTestCase(TestCase):
         update_fp_only : bool
             Some tests operate on filepaths only - files do not actually need
             to exist. Thus, we don't need to tranfer a file.
+
+        Returns
+        -------
+        The potentially modified filepaths.
         """
+        def _stripRoot(fp):
+            # chop off leading / for join to work properly when prepending
+            # the BASE_DATA_DIR
+            if isabs(fp):
+                return fp[len(sep):]
+            return fp
+
         if self.qclient._plugincoupling == 'filesystem':
             return fps
 
@@ -117,13 +128,13 @@ class PluginTestCase(TestCase):
         if isinstance(fps, str):
             if not update_fp_only:
                 self.qclient.push_file_to_central(fps)
-            return join(base_data_dir, relpath(fps, sep))
+            return join(base_data_dir, _stripRoot(fps))
         elif isinstance(fps, list):
             for fp in fps:
                 if not update_fp_only:
                     self.qclient.push_file_to_central(fp)
-            return [join(base_data_dir, relpath(fp, sep)) for fp in fps]
+            return [join(base_data_dir, _stripRoot(fp)) for fp in fps]
         else:
             raise ValueError(
-                "_deposite_in_qiita_basedir is not implemented for type %s"
+                "deposite_in_qiita_basedir is not implemented for type %s"
                 % type(fps))

--- a/qiita_client/testing.py
+++ b/qiita_client/testing.py
@@ -11,6 +11,7 @@ from os import environ
 from time import sleep
 
 from qiita_client import QiitaClient
+from plugin import BaseQiitaPlugin
 
 import logging
 
@@ -36,6 +37,14 @@ class PluginTestCase(TestCase):
         logger.debug(
             'PluginTestCase.setUpClass() token %s' % cls.qclient._token)
         cls.qclient.post('/apitest/reload_plugins/')
+
+        # When testing, we access plugin functions often directly. Plugin
+        # configuration files are not parsed in these cases. To be able to
+        # change the plugin coupling protocol, we resort to the environment
+        # variable here.
+        cls.qclient._plugincoupling = environ.get(
+            'QIITA_PLUGINCOUPLING', BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS)
+
         # Give enough time for the plugins to register
         sleep(5)
 

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -73,6 +73,23 @@ class QiitaCommandTest(TestCase):
                            self.exp_opt, self.exp_out, self.exp_dflt)
         self.assertEqual(obs('a', 'b', 'c', 'd'), 42)
 
+    def test__push_artifacts_files_to_central(self):
+        class fakeClient():
+            def push_file_to_central(self, fp):
+                return 'pushed:%s' % fp
+
+        obs = QiitaCommand._push_artifacts_files_to_central(
+            fakeClient(), [
+                ArtifactInfo("stefArtiName", "Atype", [
+                    ("fp1", "preprocessed_fasta"),
+                    ("fp2", "preprocessed_fastq")]),
+                None,
+                ArtifactInfo("artiName", "artiType", [])])
+
+        self.assertIn('pushed:', obs[0].files[0][0])
+        self.assertIn('pushed:', obs[0].files[1][0])
+        self.assertEqual([], obs[2].files)
+
 
 class QiitaArtifactTypeTest(TestCase):
     def test_init(self):

--- a/qiita_client/tests/test_plugin.py
+++ b/qiita_client/tests/test_plugin.py
@@ -75,20 +75,20 @@ class QiitaCommandTest(TestCase):
 
     def test__push_artifacts_files_to_central(self):
         class fakeClient():
-            def push_file_to_central(self, fp):
-                return 'pushed:%s' % fp
+            def push_file_to_central(self, filepath):
+                return 'pushed:%s' % filepath
 
-        obs = QiitaCommand._push_artifacts_files_to_central(
-            fakeClient(), [
-                ArtifactInfo("stefArtiName", "Atype", [
-                    ("fp1", "preprocessed_fasta"),
-                    ("fp2", "preprocessed_fastq")]),
-                None,
-                ArtifactInfo("artiName", "artiType", [])])
+        artifacts = [
+            ArtifactInfo("stefArtiName", "Atype", [
+                ("fp1", "preprocessed_fasta"),
+                ("fp2", "preprocessed_fastq")]),
+            None,
+            ArtifactInfo("artiName", "artiType", [])]
+        QiitaCommand._push_artifacts_files_to_central(fakeClient(), artifacts)
 
-        self.assertIn('pushed:', obs[0].files[0][0])
-        self.assertIn('pushed:', obs[0].files[1][0])
-        self.assertEqual([], obs[2].files)
+        self.assertIn('pushed:', artifacts[0].files[0][0])
+        self.assertIn('pushed:', artifacts[0].files[1][0])
+        self.assertEqual([], artifacts[2].files)
 
 
 class QiitaArtifactTypeTest(TestCase):

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -550,6 +550,10 @@ class QiitaClientTests(PluginTestCase):
         fp_obs = self.tester.fetch_file_from_central(fp_test, prefix=prefix)
         print("@@@@@@@@@@@STEFAN 2", prefix, fp_test, fp_obs)
 
+        from glob import glob
+        for fp in glob("%s/**/*" % prefix, recursive=True):
+            print("@@@@@@@@@@@ STEFAN present: %s" % fp)
+
         # test a file of the freshly transferred directory from main has
         # expected file content
         with open(join(fp_obs, 'testdir', 'fileA.txt'), 'r') as f:
@@ -558,3 +562,15 @@ class QiitaClientTests(PluginTestCase):
 
 if __name__ == '__main__':
     main()
+
+# # [Errno 2] No such file or directory: 
+# # '/home/runner/localFetch
+# #  /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
+# #  job/2_test_folder/testdir/fileA.txt'
+
+# [
+#     <ZipInfo filename='job/2_test_folder/testdir/fileA.txt' filemode='?--S-wx-w-' external_attr=0x4000 file_size=9>, 
+#     <ZipInfo filename='job/2_test_folder/testdir/subdirB_l1/fileE.sff' filemode='?--S-wx-w-' external_attr=0x4000 file_size=5>, 
+#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/fileB.fna' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>, 
+#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq' filemode='?--S-wx-w-' external_attr=0x4000 file_size=4>, 
+#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>]

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -511,20 +511,10 @@ class QiitaClientTests(PluginTestCase):
 
             # delete file and test if it is gone
             fp_deleted = self.qclient.delete_file_from_central(fp_test)
-            if protocol == 'filesystem':
-                # all three fp should point to the same filepath
-                self.assertFalse(exists(fp_obs))
-                self.assertFalse(exists(fp_test))
-                self.assertFalse(exists(fp_deleted))
-            elif protocol == 'https':
-                # as of 2025-09-26, I don't allow deletion of qiita main files
-                # through API endpoints. Thus, the file is NOT deleted!
-                # local version of the file
-                self.assertTrue(exists(fp_test))
-                # qiita main filepath
-                self.assertTrue(exists(fp_obs))
-                # qiita main filepath, returned by delete_file_from_central
-                self.assertTrue(exists(fp_deleted))
+            # all three fp should point to the same filepath
+            self.assertFalse(exists(fp_obs))
+            self.assertFalse(exists(fp_test))
+            self.assertFalse(exists(fp_deleted))
 
     def test_fetch_directory(self):
         # a bit hacky, but should work as long as test database does not change

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -545,14 +545,15 @@ class QiitaClientTests(PluginTestCase):
         # QIITA_BASE_DIR
         print(">>>>>C>>>>>>>", dirname(fp_main), file=sys.stderr)
         import os
-        with open(os.environ['NGINX_FILE_NEW'], 'r') as f:
+
+        with open("/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_pet/nginx_example_local.conf", 'r') as f:
             for l in f.readlines():
                 print(">>>>>>>>>>>> NGINX >>> %s" % l, file=sys.stderr)
-        with open(os.environ['QIITA_CONFIG_FP'], 'r') as f:
+        with open('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_core/support_files/config_test_local.cfg', 'r') as f:
             for l in f.readlines():
                 print(">>>>>>>>>>>> Q-Conf >>> %s" % l, file=sys.stderr)
         from glob import glob
-        for f in glob('%s/**/*' % fp_main, recursive=True):
+        for f in glob('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/**/*', recursive=True):
             print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
 
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -18,7 +18,7 @@ from shutil import rmtree
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
 from qiita_client.testing import PluginTestCase, URL
-from qiita_client.exceptions import BadRequestError
+from qiita_client.exceptions import BadRequestError, ForbiddenError
 
 CLIENT_ID = '19ndkO3oMKsoChjVVWluF7QkxHRfYhTKSFbAVt8IhK7gZgDaO4'
 BAD_CLIENT_ID = 'NOT_A_CLIENT_ID'
@@ -497,12 +497,17 @@ class QiitaClientTests(PluginTestCase):
             self.qclient._plugincoupling = protocol
 
             # deposit a test file
-            fp_test = join(cwd, 'deletme_%s.txt' % protocol)
+            fp_test = join(cwd, 'deleteme_%s.txt' % protocol)
             makedirs(cwd, exist_ok=True)
             with open(fp_test, 'w') as f:
                 f.write('This is a testfile content\n')
             self.clean_up_files.append(fp_test)
-            self.qclient.push_file_to_central(fp_test)
+            try:
+                self.qclient.push_file_to_central(fp_test)
+            except ForbiddenError as e:
+                # previous test instances might not have cleaned this file
+                # properly if ran with https protocol
+                pass
 
             # sanity check that test file has been deposited correctly
             fp_obs = self.qclient.fetch_file_from_central(fp_test)

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -569,7 +569,7 @@ if __name__ == '__main__':
     main()
 
 
->>>>>>>>>>>> ./job/2_test_folder/source /qiita_data/./job/2_test_folder/source /qiita_data/./job/2_test_folder
-2025-11-06T14:51:59.6108533Z >>>>>A>>>>>>> ./job/2_test_folder/source
-2025-11-06T14:51:59.6655140Z >>>>>B>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder/source
-2025-11-06T14:51:59.6656458Z >>>>>C>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder
+# >>>>>>>>>>>> ./job/2_test_folder/source /qiita_data/./job/2_test_folder/source /qiita_data/./job/2_test_folder
+# 2025-11-06T14:51:59.6108533Z >>>>>A>>>>>>> ./job/2_test_folder/source
+# 2025-11-06T14:51:59.6655140Z >>>>>B>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder/source
+# 2025-11-06T14:51:59.6656458Z >>>>>C>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -14,7 +14,7 @@ from tempfile import mkstemp
 from json import dumps
 import pandas as pd
 from shutil import rmtree
-from collections import namedtuple
+from pathlib import Path
 
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
@@ -545,7 +545,7 @@ class QiitaClientTests(PluginTestCase):
         ainfo = self.qclient.get('/qiita_db/artifacts/1/')
         base_data_dir = ainfo['files']['raw_forward_seqs'][0]['filepath'][
             :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
-        fp_main = join(base_data_dir, fp_test)
+        fp_main = join(base_data_dir, join(*Path(fp_test).parts))
 
         # fakeTest = namedtuple("fakeTest", "qclient")
         # fakeTest.qclient = self.tester

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -504,7 +504,7 @@ class QiitaClientTests(PluginTestCase):
             self.clean_up_files.append(fp_test)
             try:
                 self.qclient.push_file_to_central(fp_test)
-            except ForbiddenError as e:
+            except ForbiddenError:
                 # previous test instances might not have cleaned this file
                 # properly if ran with https protocol
                 pass

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -535,10 +535,22 @@ class QiitaClientTests(PluginTestCase):
         self._create_test_dir(prefix=fp_test)
 
         # transmitting test directory into qiita main
+        # self.tester._plugincoupling = 'https'
+        # fakeTest = namedtuple("fakeTest", "qclient")
+        # fakeTest.qclient = self.tester
+        # fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
         self.tester._plugincoupling = 'https'
-        fakeTest = namedtuple("fakeTest", "qclient")
-        fakeTest.qclient = self.tester
-        fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
+        self.tester.push_file_to_central(fp_test)
+        # a bit hacky, but should work as long as test database does not change
+        ainfo = self.qclient.get('/qiita_db/artifacts/1/')
+        base_data_dir = ainfo['files']['raw_forward_seqs'][0]['filepath'][
+            :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
+        fp_main = join(base_data_dir, fp_test)
+
+        # fakeTest = namedtuple("fakeTest", "qclient")
+        # fakeTest.qclient = self.tester
+        # fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
+        
         print(">>>>>B>>>>>>>", fp_main, file=sys.stderr)
         
         # fetch test directory from qiita main, this time storing it at
@@ -555,6 +567,7 @@ class QiitaClientTests(PluginTestCase):
         from glob import glob
         for f in glob('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/**/*', recursive=True):
             print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
+
 
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))
         # test a file of the freshly transferred directory from main has

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -18,7 +18,7 @@ from shutil import rmtree
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
 from qiita_client.testing import PluginTestCase, URL
-from qiita_client.exceptions import BadRequestError, ForbiddenError
+from qiita_client.exceptions import BadRequestError
 
 CLIENT_ID = '19ndkO3oMKsoChjVVWluF7QkxHRfYhTKSFbAVt8IhK7gZgDaO4'
 BAD_CLIENT_ID = 'NOT_A_CLIENT_ID'

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -528,8 +528,10 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_deleted))
 
     def test_fetch_directory(self):
+        import sys
         # creating a test directory
         fp_test = join('./job', '2_test_folder', 'source')
+        print(">>>>>A>>>>>>>", fp_test, file=sys.stderr)
         self._create_test_dir(prefix=fp_test)
 
         # transmitting test directory into qiita main
@@ -537,16 +539,17 @@ class QiitaClientTests(PluginTestCase):
         fakeTest = namedtuple("fakeTest", "qclient")
         fakeTest.qclient = self.tester
         fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
-
+        print(">>>>>B>>>>>>>", fp_main, file=sys.stderr)
+        
         # fetch test directory from qiita main, this time storing it at
         # QIITA_BASE_DIR
+        print(">>>>>C>>>>>>>", dirname(fp_main), file=sys.stderr)
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))
         # test a file of the freshly transferred directory from main has
         # expected file content
         with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
             self.assertIn('contentA', '\n'.join(f.readlines()))
 
-        import sys
         print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
         print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs)
 

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -558,22 +558,22 @@ class QiitaClientTests(PluginTestCase):
         print(">>>>>C>>>>>>>", dirname(fp_main), file=sys.stderr)
         import os
 
-        with open("/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_pet/nginx_example_local.conf", 'r') as f:
-            for l in f.readlines():
-                print(">>>>>>>>>>>> NGINX >>> %s" % l, file=sys.stderr)
-        with open('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_core/support_files/config_test_local.cfg', 'r') as f:
-            for l in f.readlines():
-                print(">>>>>>>>>>>> Q-Conf >>> %s" % l, file=sys.stderr)
-        from glob import glob
-        for f in glob('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/**/*', recursive=True):
-            print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
+        # with open("/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_pet/nginx_example_local.conf", 'r') as f:
+        #     for l in f.readlines():
+        #         print(">>>>>>>>>>>> NGINX >>> %s" % l, file=sys.stderr)
+        # with open('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_core/support_files/config_test_local.cfg', 'r') as f:
+        #     for l in f.readlines():
+        #         print(">>>>>>>>>>>> Q-Conf >>> %s" % l, file=sys.stderr)
+        # from glob import glob
+        # for f in glob('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/**/*', recursive=True):
+        #     print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
 
-
-        fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))
-        # test a file of the freshly transferred directory from main has
-        # expected file content
-        with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
-            self.assertIn('contentA', '\n'.join(f.readlines()))
+        prefix = join(expanduser("~"), 'karl')
+        fp_obs = self.tester.fetch_file_from_central(dirname(fp_main), prefix=prefix)
+        # # test a file of the freshly transferred directory from main has
+        # # expected file content
+        # with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
+        #     self.assertIn('contentA', '\n'.join(f.readlines()))
 
         print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
         print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs)

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -502,12 +502,7 @@ class QiitaClientTests(PluginTestCase):
             with open(fp_test, 'w') as f:
                 f.write('This is a testfile content\n')
             self.clean_up_files.append(fp_test)
-            try:
-                self.qclient.push_file_to_central(fp_test)
-            except ForbiddenError:
-                # previous test instances might not have cleaned this file
-                # properly if ran with https protocol
-                pass
+            self.qclient.push_file_to_central(fp_test)
 
             # sanity check that test file has been deposited correctly
             fp_obs = self.qclient.fetch_file_from_central(fp_test)
@@ -529,6 +524,12 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_obs))
                 # qiita main filepath, returned by delete_file_from_central
                 self.assertTrue(exists(fp_deleted))
+
+                # clean up test file directly after tests have passed
+                if exists(fp_test):
+                    remove(fp_test)
+                if exists(fp_obs):
+                    remove(fp_obs)
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -624,3 +624,4 @@ if __name__ == '__main__':
     # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/fileB.fna job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
     # '- 4 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n', 
     # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n']
+

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -14,6 +14,7 @@ from tempfile import mkstemp
 from json import dumps
 import pandas as pd
 from shutil import rmtree
+from collections import namedtuple
 
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
@@ -525,6 +526,25 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_obs))
                 # qiita main filepath, returned by delete_file_from_central
                 self.assertTrue(exists(fp_deleted))
+
+    def test_fetch_directory(self):
+        # creating a test directory
+        fp_test = join('/job', '2_test_folder', 'source')
+        self._create_test_dir(prefix=fp_test)
+
+        # transmitting test directory into qiita main
+        self.tester._plugincoupling = 'https'
+        fakeTest = namedtuple("fakeTest", "qclient")
+        fakeTest.qclient = self.tester
+        fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
+
+        # fetch test directory from qiita main, this time storing it at
+        # QIITA_BASE_DIR
+        fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))
+        # test a file of the freshly transferred directory from main has
+        # expected file content
+        with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
+            self.assertIn('contentA', '\n'.join(f.readlines()))
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -596,7 +596,6 @@ if __name__ == '__main__':
 
 
 
-
 # github
 #   base_data_dir: /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
 #   prefix: /home/runner/localFetch

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -546,36 +546,11 @@ class QiitaClientTests(PluginTestCase):
         prefix = join(expanduser("~"), 'localFetch')
         fp_obs = self.tester.fetch_file_from_central(
             dirname(fp_main), prefix=prefix)
-        
-        import sys
-        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
-        from glob import glob
-        for fp in glob("%s/**/*" % fp_obs, recursive=True):
-            print(">>>>>>>>glob>>>> %s" % fp)
-        # >>>>>>>>>>>> ./job/2_test_folder/source /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source /home/runner/karl/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder
-        #                             /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder
-        # No such file or directory: '/home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source/testdir/fileA.txt'
-
-# 2025-11-07T08:12:39.6827567Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job
-# 2025-11-07T08:12:39.6828500Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder
-# 2025-11-07T08:12:39.6829468Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job
-# 2025-11-07T08:12:39.6830521Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder
-# 2025-11-07T08:12:39.6831641Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source
-# 2025-11-07T08:12:39.6832764Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir
-# 2025-11-07T08:12:39.6833951Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/fileA.txt
-# 2025-11-07T08:12:39.6835367Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirB_l1
-# 2025-11-07T08:12:39.6836581Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1
-# 2025-11-07T08:12:39.6837856Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirB_l1/fileE.sff
-# 2025-11-07T08:12:39.6839142Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/fileB.fna
-# 2025-11-07T08:12:39.6840407Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2
-# 2025-11-07T08:12:39.6841923Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2/fileD.seq
-# 2025-11-07T08:12:39.6843318Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2/fileC.log
-
-# No such file or directory:                   '/home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source/testdir/fileA.txt'
 
         # test a file of the freshly transferred directory from main has
         # expected file content
-        with open(join(fp_obs, 'job/2_test_folder/job/2_test_folder/', 'source', 'testdir', 'fileA.txt'), 'r') as f:
+        with open(join(fp_obs, 'job/2_test_folder/job/2_test_folder/',
+                       'source', 'testdir', 'fileA.txt'), 'r') as f:
             self.assertIn('contentA', '\n'.join(f.readlines()))
 
 

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -544,6 +544,17 @@ class QiitaClientTests(PluginTestCase):
         # fetch test directory from qiita main, this time storing it at
         # QIITA_BASE_DIR
         print(">>>>>C>>>>>>>", dirname(fp_main), file=sys.stderr)
+        import os
+        with open(os.environ['NGINX_FILE_NEW'], 'r') as f:
+            for l in f.readlines():
+                print(">>>>>>>>>>>> NGINX >>> %s" % l, file=sys.stderr)
+        with open(os.environ['QIITA_CONFIG_FP'], 'r') as f:
+            for l in f.readlines():
+                print(">>>>>>>>>>>> Q-Conf >>> %s" % l, file=sys.stderr)
+        from glob import glob
+        for f in glob('%s/**/*' % fp_main, recursive=True):
+            print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
+
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main))
         # test a file of the freshly transferred directory from main has
         # expected file content
@@ -556,3 +567,9 @@ class QiitaClientTests(PluginTestCase):
 
 if __name__ == '__main__':
     main()
+
+
+>>>>>>>>>>>> ./job/2_test_folder/source /qiita_data/./job/2_test_folder/source /qiita_data/./job/2_test_folder
+2025-11-06T14:51:59.6108533Z >>>>>A>>>>>>> ./job/2_test_folder/source
+2025-11-06T14:51:59.6655140Z >>>>>B>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder/source
+2025-11-06T14:51:59.6656458Z >>>>>C>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -554,6 +554,9 @@ class QiitaClientTests(PluginTestCase):
         for fp in glob("%s/**/*" % prefix, recursive=True):
             print("@@@@@@@@@@@ STEFAN present: %s" % fp)
 
+        with open('/tmp/stefan.log') as f:
+            print("üüüüüüüüüü log from qiita\n %s" % f.readlines())
+
         # test a file of the freshly transferred directory from main has
         # expected file content
         with open(join(fp_obs, 'testdir', 'fileA.txt'), 'r') as f:
@@ -574,3 +577,30 @@ if __name__ == '__main__':
 #     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/fileB.fna' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>, 
 #     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq' filemode='?--S-wx-w-' external_attr=0x4000 file_size=4>, 
 #     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>]
+
+# tinqiita:
+#    base_data_dir: /qiita_data/
+#    prefix: /root/localFetch/
+#    deposited file locations
+#       <prefix>/<base_data_dir>/job/2_test_folder/testdir/fileA.txt /root/localFetch/qiita_data/job/2_test_folder/testdir/fileA.txt
+#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
+#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
+#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
+#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/fileA.txt
+# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
+# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
+# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
+# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+
+
+# github:
+#    base_data_dir: /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
+#    prefix: /home/runner/localFetch
+#    deposited file locations
+#       <prefix>/<basa_data_dir>/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
+#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
+#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirB_l1/fileE.sff
+#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/fileB.fna
+#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -546,6 +546,10 @@ class QiitaClientTests(PluginTestCase):
         with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
             self.assertIn('contentA', '\n'.join(f.readlines()))
 
+        import sys
+        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
+        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs)
+
 
 if __name__ == '__main__':
     main()

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -8,11 +8,12 @@
 
 from unittest import TestCase, main
 import filecmp
-from os import remove, close
-from os.path import basename, exists, expanduser, join
+from os import remove, close, makedirs
+from os.path import basename, exists, expanduser, join, isdir
 from tempfile import mkstemp
 from json import dumps
 import pandas as pd
+from shutil import rmtree
 
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
@@ -110,7 +111,10 @@ class QiitaClientTests(PluginTestCase):
     def tearDown(self):
         for fp in self.clean_up_files:
             if exists(fp):
-                remove(fp)
+                if isdir(fp):
+                    rmtree(fp)
+                else:
+                    remove(fp)
 
     def test_init(self):
         obs = QiitaClient(URL,
@@ -184,7 +188,7 @@ class QiitaClientTests(PluginTestCase):
         with open(fp, 'w') as f:
             f.write('\n')
         self.clean_up_files.append(fp)
-        obs = self.tester.patch(f'/qiita_db/artifacts/{artifact_id}/', 'add',
+        obs = self.tester.patch('/qiita_db/artifacts/%s/' % artifact_id, 'add',
                                 '/html_summary/', value=fp)
         self.assertIsNone(obs)
 
@@ -439,6 +443,50 @@ class QiitaClientTests(PluginTestCase):
         self.clean_up_files.append(fp_source)
         fp_obs = self.tester.push_file_to_central(fp_source)
         self.assertEqual(fp_source, fp_obs)
+
+    def _create_test_dir(self, prefix=None):
+        """Creates a test directory with files and subdirs."""
+        # prefix
+        # |- testdir/
+        # |---- fileA.txt
+        # |---- subdirA_l1/
+        # |-------- fileB.fna
+        # |-------- subdirC_l2/
+        # |------------ fileC.log
+        # |------------ fileD.seq
+        # |---- subdirB_l1/
+        # |-------- fileE.sff
+        if (prefix is not None) and (prefix != ""):
+            prefix = join(prefix, 'testdir')
+        else:
+            prefix = 'testdir'
+
+        for dir in [join(prefix, 'subdirA_l1', 'subdirC_l2'),
+                    join(prefix, 'subdirB_l1')]:
+            if not exists(dir):
+                makedirs(dir)
+        for file, cont in [(join(prefix, 'fileA.txt'), 'contentA'),
+                           (join(prefix, 'subdirA_l1',
+                                 'fileB.fna'), 'this is B'),
+                           (join(prefix, 'subdirA_l1', 'subdirC_l2',
+                                 'fileC.log'), 'call me c'),
+                           (join(prefix, 'subdirA_l1', 'subdirC_l2',
+                                 'fileD.seq'), 'I d'),
+                           (join(prefix, 'subdirB_l1', 'fileE.sff'), 'oh e')]:
+            with open(file, "w") as f:
+                f.write(cont + "\n")
+        self.clean_up_files.append(prefix)
+
+        return prefix
+
+    def test_push_file_to_central_dir(self):
+        self.tester._plugincoupling = 'https'
+
+        fp_source = self._create_test_dir('/tmp/test_push_dir/')
+        fp_obs = self.tester.push_file_to_central(fp_source)
+        self.assertEqual(fp_source, fp_obs)
+        # As we don't necessarily know the QIITA_BASE_DIR, we cannot fetch one
+        # of the files to double check for it's content
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -532,8 +532,6 @@ class QiitaClientTests(PluginTestCase):
         base_data_dir = ainfo['files']['raw_forward_seqs'][0]['filepath'][
             :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
 
-        print("@@@@@@@@@@@STEFAN", base_data_dir)
-
         # creating a LOCAL test directory within base_data_dir as the DB entry
         # but no files exist. "job" is the according mountpoint
         fp_test = join(base_data_dir, 'job', '2_test_folder')
@@ -548,14 +546,6 @@ class QiitaClientTests(PluginTestCase):
         # (=prefix) than it was generated
         prefix = join(expanduser("~"), 'localFetch')
         fp_obs = self.tester.fetch_file_from_central(fp_test, prefix=prefix)
-        print("@@@@@@@@@@@STEFAN 2", prefix, fp_test, fp_obs)
-
-        from glob import glob
-        for fp in glob("%s/**/*" % prefix, recursive=True):
-            print("@@@@@@@@@@@ STEFAN present: %s" % fp)
-
-        with open('/tmp/stefan.log') as f:
-            print("üüüüüüüüüü log from qiita\n %s" % f.readlines())
 
         # test a file of the freshly transferred directory from main has
         # expected file content
@@ -565,62 +555,3 @@ class QiitaClientTests(PluginTestCase):
 
 if __name__ == '__main__':
     main()
-
-# tinqiita
-#   base_data_dir: /qiita_data/
-#   prefix: /root/localFetch
-#   actual files after fetch
-# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/fileA.txt
-# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
-# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
-# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
-# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
-#   files at Main:
-#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/fileA.txt\n', 
-#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
-#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
-#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n', 
-#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n']
-#   when fetching dir
-#       <ZipInfo filename='testdir/fileA.txt' compress_type=deflate filemode='-rw-r--r--' file_size=9 compress_size=11>, 
-#       <ZipInfo filename='testdir/subdirB_l1/fileE.sff' compress_type=deflate filemode='-rw-r--r--' file_size=5 compress_size=7>, 
-#       <ZipInfo filename='testdir/subdirA_l1/fileB.fna' compress_type=deflate filemode='-rw-r--r--' file_size=10 compress_size=10>, 
-#       <ZipInfo filename='testdir/subdirA_l1/subdirC_l2/fileC.log' compress_type=deflate filemode='-rw-r--r--' file_size=10 compress_size=12>, 
-#       <ZipInfo filename='testdir/subdirA_l1/subdirC_l2/fileD.seq' compress_type=deflate filemode='-rw-r--r--' file_size=4 compress_size=6>]
-
-# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/fileA.txt testdir/fileA.txt
-# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff testdir/subdirB_l1/fileE.sff
-# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna testdir/subdirA_l1/fileB.fna
-# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log testdir/subdirA_l1/subdirC_l2/fileC.log
-# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq testdir/subdirA_l1/subdirC_l2/fileD.seq\n']
-
-
-
-# github
-#   base_data_dir: /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
-#   prefix: /home/runner/localFetch
-#   actual files after fetch
-# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
-# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirB_l1/fileE.sff
-# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/fileB.fna
-# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
-# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
-#   files at Main:
-#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/fileA.txt\n', 
-#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
-#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
-#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n', 
-#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n']
-#   when fetching dir
-#       <ZipInfo filename='job/2_test_folder/testdir/fileA.txt' filemode='?--S-wx-w-' external_attr=0x4000 file_size=9>, 
-#       <ZipInfo filename='job/2_test_folder/testdir/subdirB_l1/fileE.sff' filemode='?--S-wx-w-' external_attr=0x4000 file_size=5>, 
-#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/fileB.fna' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>, 
-#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq' filemode='?--S-wx-w-' external_attr=0x4000 file_size=4>, 
-#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>]
-# all_files
-    # '- 9 /protected/job/2_test_folder/testdir/fileA.txt job/2_test_folder/testdir/fileA.txt\n', 
-    # '- 5 /protected/job/2_test_folder/testdir/subdirB_l1/fileE.sff job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
-    # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/fileB.fna job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
-    # '- 4 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n', 
-    # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n']
-

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -543,12 +543,18 @@ class QiitaClientTests(PluginTestCase):
 
         # fetch test directory from qiita main, this time storing it at
         # QIITA_BASE_DIR
-        prefix = join(expanduser("~"), 'karl')
+        prefix = join(expanduser("~"), 'localFetch')
         fp_obs = self.tester.fetch_file_from_central(
             dirname(fp_main), prefix=prefix)
         
         import sys
         print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
+        from glob import glob
+        for fp in glob("%s/**/*" % fp_obs, recursive=True):
+            print(">>>>>>>>glob>>>> %s" % fp)
+        # >>>>>>>>>>>> ./job/2_test_folder/source /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source /home/runner/karl/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder
+        #                             /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder
+        # No such file or directory: '/home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source/testdir/fileA.txt'
 
         # test a file of the freshly transferred directory from main has
         # expected file content

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -556,9 +556,26 @@ class QiitaClientTests(PluginTestCase):
         #                             /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder
         # No such file or directory: '/home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source/testdir/fileA.txt'
 
+# 2025-11-07T08:12:39.6827567Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job
+# 2025-11-07T08:12:39.6828500Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder
+# 2025-11-07T08:12:39.6829468Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job
+# 2025-11-07T08:12:39.6830521Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder
+# 2025-11-07T08:12:39.6831641Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source
+# 2025-11-07T08:12:39.6832764Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir
+# 2025-11-07T08:12:39.6833951Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/fileA.txt
+# 2025-11-07T08:12:39.6835367Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirB_l1
+# 2025-11-07T08:12:39.6836581Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1
+# 2025-11-07T08:12:39.6837856Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirB_l1/fileE.sff
+# 2025-11-07T08:12:39.6839142Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/fileB.fna
+# 2025-11-07T08:12:39.6840407Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2
+# 2025-11-07T08:12:39.6841923Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2/fileD.seq
+# 2025-11-07T08:12:39.6843318Z >>>>>>>>glob>>>> /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/job/2_test_folder/source/testdir/subdirA_l1/subdirC_l2/fileC.log
+
+# No such file or directory:                   '/home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/source/testdir/fileA.txt'
+
         # test a file of the freshly transferred directory from main has
         # expected file content
-        with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
+        with open(join(fp_obs, 'job/2_test_folder/job/2_test_folder/', 'source', 'testdir', 'fileA.txt'), 'r') as f:
             self.assertIn('contentA', '\n'.join(f.readlines()))
 
 

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -528,17 +528,11 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_deleted))
 
     def test_fetch_directory(self):
-        import sys
         # creating a test directory
         fp_test = join('./job', '2_test_folder', 'source')
-        print(">>>>>A>>>>>>>", fp_test, file=sys.stderr)
         self._create_test_dir(prefix=fp_test)
 
         # transmitting test directory into qiita main
-        # self.tester._plugincoupling = 'https'
-        # fakeTest = namedtuple("fakeTest", "qclient")
-        # fakeTest.qclient = self.tester
-        # fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
         self.tester._plugincoupling = 'https'
         self.tester.push_file_to_central(fp_test)
         # a bit hacky, but should work as long as test database does not change
@@ -547,45 +541,16 @@ class QiitaClientTests(PluginTestCase):
             :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
         fp_main = join(base_data_dir, join(*Path(fp_test).parts))
 
-        # fakeTest = namedtuple("fakeTest", "qclient")
-        # fakeTest.qclient = self.tester
-        # fp_main = PluginTestCase.deposite_in_qiita_basedir(fakeTest, fp_test)
-        
-        print(">>>>>B>>>>>>>", fp_main, file=sys.stderr)
-        
         # fetch test directory from qiita main, this time storing it at
         # QIITA_BASE_DIR
-        print(">>>>>C>>>>>>>", dirname(fp_main), file=sys.stderr)
-        import os
-
-        # with open("/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_pet/nginx_example_local.conf", 'r') as f:
-        #     for l in f.readlines():
-        #         print(">>>>>>>>>>>> NGINX >>> %s" % l, file=sys.stderr)
-        # with open('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_core/support_files/config_test_local.cfg', 'r') as f:
-        #     for l in f.readlines():
-        #         print(">>>>>>>>>>>> Q-Conf >>> %s" % l, file=sys.stderr)
-        # from glob import glob
-        # for f in glob('/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/**/*', recursive=True):
-        #     print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
-
         prefix = join(expanduser("~"), 'karl')
-        self.tester._server_url.replace('8383', '21174')
-        print(">>>>>server url>>>>>>>", self.tester._server_url, file=sys.stderr)
-        fp_obs = self.tester.fetch_file_from_central(dirname(fp_main), prefix=prefix)
-        # # test a file of the freshly transferred directory from main has
-        # # expected file content
-        # with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
-        #     self.assertIn('contentA', '\n'.join(f.readlines()))
-
-        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
-        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs)
+        fp_obs = self.tester.fetch_file_from_central(
+            dirname(fp_main), prefix=prefix)
+        # test a file of the freshly transferred directory from main has
+        # expected file content
+        with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:
+            self.assertIn('contentA', '\n'.join(f.readlines()))
 
 
 if __name__ == '__main__':
     main()
-
-
-# >>>>>>>>>>>> ./job/2_test_folder/source /qiita_data/./job/2_test_folder/source /qiita_data/./job/2_test_folder
-# 2025-11-06T14:51:59.6108533Z >>>>>A>>>>>>> ./job/2_test_folder/source
-# 2025-11-06T14:51:59.6655140Z >>>>>B>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder/source
-# 2025-11-06T14:51:59.6656458Z >>>>>C>>>>>>> /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/./job/2_test_folder

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -502,9 +502,10 @@ class QiitaClientTests(PluginTestCase):
             with open(fp_test, 'w') as f:
                 f.write('This is a testfile content\n')
             self.clean_up_files.append(fp_test)
-            self.qclient.push_file_to_central(fp_test)
 
             # sanity check that test file has been deposited correctly
+            # no push required, as in this test local and remote QIITA_BASE_DIR
+            # is identical
             fp_obs = self.qclient.fetch_file_from_central(fp_test)
             self.assertTrue(exists(fp_obs))
 
@@ -524,12 +525,6 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_obs))
                 # qiita main filepath, returned by delete_file_from_central
                 self.assertTrue(exists(fp_deleted))
-
-                # clean up test file directly after tests have passed
-                if exists(fp_test):
-                    remove(fp_test)
-                if exists(fp_obs):
-                    remove(fp_obs)
 
 
 if __name__ == '__main__':

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -14,7 +14,6 @@ from tempfile import mkstemp
 from json import dumps
 import pandas as pd
 from shutil import rmtree
-from pathlib import Path
 
 from qiita_client.qiita_client import (QiitaClient, _format_payload,
                                        ArtifactInfo)
@@ -528,29 +527,32 @@ class QiitaClientTests(PluginTestCase):
                 self.assertTrue(exists(fp_deleted))
 
     def test_fetch_directory(self):
-        # creating a test directory
-        fp_test = join('./job', '2_test_folder', 'source')
-        self._create_test_dir(prefix=fp_test)
-
-        # transmitting test directory into qiita main
-        self.tester._plugincoupling = 'https'
-        self.tester.push_file_to_central(fp_test)
         # a bit hacky, but should work as long as test database does not change
         ainfo = self.qclient.get('/qiita_db/artifacts/1/')
         base_data_dir = ainfo['files']['raw_forward_seqs'][0]['filepath'][
             :(-1 * len('raw_data/1_s_G1_L001_sequences.fastq.gz'))]
-        fp_main = join(base_data_dir, join(*Path(fp_test).parts))
 
-        # fetch test directory from qiita main, this time storing it at
-        # QIITA_BASE_DIR
+        print("@@@@@@@@@@@STEFAN", base_data_dir)
+
+        # creating a LOCAL test directory within base_data_dir as the DB entry
+        # but no files exist. "job" is the according mountpoint
+        fp_test = join(base_data_dir, 'job', '2_test_folder')
+        self._create_test_dir(prefix=fp_test)
+
+        # transmitting test directory to qiita main (remote)
+        self.tester._plugincoupling = 'https'
+        self.tester.push_file_to_central(fp_test)
+        # fp_main = join(base_data_dir, join(*Path(fp_test).parts))
+
+        # fetch test directory from qiita main to a different location
+        # (=prefix) than it was generated
         prefix = join(expanduser("~"), 'localFetch')
-        fp_obs = self.tester.fetch_file_from_central(
-            dirname(fp_main), prefix=prefix)
+        fp_obs = self.tester.fetch_file_from_central(fp_test, prefix=prefix)
+        print("@@@@@@@@@@@STEFAN 2", prefix, fp_test, fp_obs)
 
         # test a file of the freshly transferred directory from main has
         # expected file content
-        with open(join(fp_obs, 'job/2_test_folder/job/2_test_folder/',
-                       'source', 'testdir', 'fileA.txt'), 'r') as f:
+        with open(join(fp_obs, 'testdir', 'fileA.txt'), 'r') as f:
             self.assertIn('contentA', '\n'.join(f.readlines()))
 
 

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -566,41 +566,61 @@ class QiitaClientTests(PluginTestCase):
 if __name__ == '__main__':
     main()
 
-# # [Errno 2] No such file or directory: 
-# # '/home/runner/localFetch
-# #  /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
-# #  job/2_test_folder/testdir/fileA.txt'
+# tinqiita
+#   base_data_dir: /qiita_data/
+#   prefix: /root/localFetch
+#   actual files after fetch
+# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/fileA.txt
+# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
+# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
+# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
+# @@@@@@@@@@@ STEFAN present: /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+#   files at Main:
+#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/fileA.txt\n', 
+#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
+#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
+#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n', 
+#  'üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n']
+#   when fetching dir
+#       <ZipInfo filename='testdir/fileA.txt' compress_type=deflate filemode='-rw-r--r--' file_size=9 compress_size=11>, 
+#       <ZipInfo filename='testdir/subdirB_l1/fileE.sff' compress_type=deflate filemode='-rw-r--r--' file_size=5 compress_size=7>, 
+#       <ZipInfo filename='testdir/subdirA_l1/fileB.fna' compress_type=deflate filemode='-rw-r--r--' file_size=10 compress_size=10>, 
+#       <ZipInfo filename='testdir/subdirA_l1/subdirC_l2/fileC.log' compress_type=deflate filemode='-rw-r--r--' file_size=10 compress_size=12>, 
+#       <ZipInfo filename='testdir/subdirA_l1/subdirC_l2/fileD.seq' compress_type=deflate filemode='-rw-r--r--' file_size=4 compress_size=6>]
 
-# [
-#     <ZipInfo filename='job/2_test_folder/testdir/fileA.txt' filemode='?--S-wx-w-' external_attr=0x4000 file_size=9>, 
-#     <ZipInfo filename='job/2_test_folder/testdir/subdirB_l1/fileE.sff' filemode='?--S-wx-w-' external_attr=0x4000 file_size=5>, 
-#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/fileB.fna' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>, 
-#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq' filemode='?--S-wx-w-' external_attr=0x4000 file_size=4>, 
-#     <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>]
-
-# tinqiita:
-#    base_data_dir: /qiita_data/
-#    prefix: /root/localFetch/
-#    deposited file locations
-#       <prefix>/<base_data_dir>/job/2_test_folder/testdir/fileA.txt /root/localFetch/qiita_data/job/2_test_folder/testdir/fileA.txt
-#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
-#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
-#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
-#       /root/localFetch/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
-# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/fileA.txt
-# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff
-# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna
-# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
-# üüüüüüüü qiita filepath=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/fileA.txt testdir/fileA.txt
+# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff testdir/subdirB_l1/fileE.sff
+# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna testdir/subdirA_l1/fileB.fna
+# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log testdir/subdirA_l1/subdirC_l2/fileC.log
+# üüüüüüüü da bin ich baff=/qiita_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq testdir/subdirA_l1/subdirC_l2/fileD.seq\n']
 
 
-# github:
-#    base_data_dir: /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
-#    prefix: /home/runner/localFetch
-#    deposited file locations
-#       <prefix>/<basa_data_dir>/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
-#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
-#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirB_l1/fileE.sff
-#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/fileB.fna
-#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
-#       /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
+
+
+# github
+#   base_data_dir: /home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/
+#   prefix: /home/runner/localFetch
+#   actual files after fetch
+# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/fileA.txt
+# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirB_l1/fileE.sff
+# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/fileB.fna
+# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq
+# @@@@@@@@@@@ STEFAN present: /home/runner/localFetch/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log
+#   files at Main:
+#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/fileA.txt\n', 
+#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
+#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
+#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n', 
+#  'üüüüüüüü qiita filepath=/home/runner/work/qiita_client/qiita_client/qiita-dev/qiita_db/support_files/test_data/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n']
+#   when fetching dir
+#       <ZipInfo filename='job/2_test_folder/testdir/fileA.txt' filemode='?--S-wx-w-' external_attr=0x4000 file_size=9>, 
+#       <ZipInfo filename='job/2_test_folder/testdir/subdirB_l1/fileE.sff' filemode='?--S-wx-w-' external_attr=0x4000 file_size=5>, 
+#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/fileB.fna' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>, 
+#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq' filemode='?--S-wx-w-' external_attr=0x4000 file_size=4>, 
+#       <ZipInfo filename='job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log' filemode='?--S-wx-w-' external_attr=0x4000 file_size=10>]
+# all_files
+    # '- 9 /protected/job/2_test_folder/testdir/fileA.txt job/2_test_folder/testdir/fileA.txt\n', 
+    # '- 5 /protected/job/2_test_folder/testdir/subdirB_l1/fileE.sff job/2_test_folder/testdir/subdirB_l1/fileE.sff\n', 
+    # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/fileB.fna job/2_test_folder/testdir/subdirA_l1/fileB.fna\n', 
+    # '- 4 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileD.seq\n', 
+    # '- 10 /protected/job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log job/2_test_folder/testdir/subdirA_l1/subdirC_l2/fileC.log\n']

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -569,6 +569,7 @@ class QiitaClientTests(PluginTestCase):
         #     print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
 
         prefix = join(expanduser("~"), 'karl')
+        self.tester._server_url.replace('8383', '21174')
         print(">>>>>server url>>>>>>>", self.tester._server_url, file=sys.stderr)
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main), prefix=prefix)
         # # test a file of the freshly transferred directory from main has

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -529,7 +529,7 @@ class QiitaClientTests(PluginTestCase):
 
     def test_fetch_directory(self):
         # creating a test directory
-        fp_test = join('/job', '2_test_folder', 'source')
+        fp_test = join('./job', '2_test_folder', 'source')
         self._create_test_dir(prefix=fp_test)
 
         # transmitting test directory into qiita main

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -569,6 +569,7 @@ class QiitaClientTests(PluginTestCase):
         #     print(">>>>>>>>>>>> files >>> %s" % f, file=sys.stderr)
 
         prefix = join(expanduser("~"), 'karl')
+        print(">>>>>server url>>>>>>>", self.tester._server_url, file=sys.stderr)
         fp_obs = self.tester.fetch_file_from_central(dirname(fp_main), prefix=prefix)
         # # test a file of the freshly transferred directory from main has
         # # expected file content

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -546,6 +546,10 @@ class QiitaClientTests(PluginTestCase):
         prefix = join(expanduser("~"), 'karl')
         fp_obs = self.tester.fetch_file_from_central(
             dirname(fp_main), prefix=prefix)
+        
+        import sys
+        print(">>>>>>>>>>>>", fp_test, fp_main, fp_obs, file=sys.stderr)
+
         # test a file of the freshly transferred directory from main has
         # expected file content
         with open(join(fp_obs, 'source', 'testdir', 'fileA.txt'), 'r') as f:

--- a/qiita_client/tests/test_qiita_client.py
+++ b/qiita_client/tests/test_qiita_client.py
@@ -9,7 +9,7 @@
 from unittest import TestCase, main
 import filecmp
 from os import remove, close, makedirs
-from os.path import basename, exists, expanduser, join, isdir
+from os.path import basename, exists, expanduser, join, isdir, dirname
 from tempfile import mkstemp
 from json import dumps
 import pandas as pd
@@ -487,6 +487,43 @@ class QiitaClientTests(PluginTestCase):
         self.assertEqual(fp_source, fp_obs)
         # As we don't necessarily know the QIITA_BASE_DIR, we cannot fetch one
         # of the files to double check for it's content
+
+    def test_delete_file_from_central(self):
+        # obtain current filepaths to infer QIITA_BASE_DIR
+        ainfo = self.tester.get("/qiita_db/artifacts/%s/" % 1)
+        cwd = dirname(ainfo['files']['raw_forward_seqs'][0]['filepath'])
+
+        for protocol in ['filesystem', 'https']:
+            self.qclient._plugincoupling = protocol
+
+            # deposit a test file
+            fp_test = join(cwd, 'deletme_%s.txt' % protocol)
+            makedirs(cwd, exist_ok=True)
+            with open(fp_test, 'w') as f:
+                f.write('This is a testfile content\n')
+            self.clean_up_files.append(fp_test)
+            self.qclient.push_file_to_central(fp_test)
+
+            # sanity check that test file has been deposited correctly
+            fp_obs = self.qclient.fetch_file_from_central(fp_test)
+            self.assertTrue(exists(fp_obs))
+
+            # delete file and test if it is gone
+            fp_deleted = self.qclient.delete_file_from_central(fp_test)
+            if protocol == 'filesystem':
+                # all three fp should point to the same filepath
+                self.assertFalse(exists(fp_obs))
+                self.assertFalse(exists(fp_test))
+                self.assertFalse(exists(fp_deleted))
+            elif protocol == 'https':
+                # as of 2025-09-26, I don't allow deletion of qiita main files
+                # through API endpoints. Thus, the file is NOT deleted!
+                # local version of the file
+                self.assertTrue(exists(fp_test))
+                # qiita main filepath
+                self.assertTrue(exists(fp_obs))
+                # qiita main filepath, returned by delete_file_from_central
+                self.assertTrue(exists(fp_deleted))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi @antgonza ,

I just realized that plugin tests behave slightly different than I expected:
1. Tests often do not read the plugin configuration file, as the "commands" are directly called, instead of creating a now plugin job. Thus, a different "plugin_coupling" protocol - as stored in the config file - is not properly used for the test. To fix this, I suggest that the `PluginTestCase` class of the qiita_client also checks the environment variable `QIITA_PLUGINCOUPLING`. Thus, by setting this env, tests will enable different protocols even though they don't adhere to the value in the generated plugin configuration file. (**This PR**)
2. Resetting the DB of qiita is done by triggering the `/apitest/reset/` endpoint (and also others). However, this only works properly if qiita master is addressed. Tests therefore do **not** speak against nginx (port 8383) but directly with the master instance (port 21174). However, when sending files, I relied on delivery through nginx. If requests go directly to master, the file content will be empty - and tests fail. With PR https://github.com/qiita-spots/qiita/pull/3483 the according endpoint checks if a request was made through nginx (and then uses it's fast mechanism to deliver the file) or directly to the tornado instance (which now can also send the file in a much slower fashion). Should be fast enough for testing.

As we use qiita_client in qp-target-gene, which operates on old python2, we need to make the `makedirs` function compatible. The argument `exist_ok` did not exist in py2.

I've also added the ability to deposit not only a single file, but - if user provides a directory - recurse through this directory and iteratively deposit all found files. This is needed e.g. for qp-target-gene artifacts: https://github.com/qiita-spots/qp-target-gene/blob/858436ee6d4a1fccd35faee0b156a12953b5774a/qp_target_gene/pick_otus.py#L124

Similarly, clients can now fetch directories. As I fear that misbehaving clients might trigger fetching the whole QIITA_BASE_DIR, I am limiting this to those directories that are "managed" by Qiita's DB as filetype directory.

I realized that https://github.com/qiita-spots/qtp-sequencing/blob/4a325e7a75ca989eea9d9029acd02be2384a601e/qtp_sequencing/validate.py#L81 is directly deleting files in QIITA_BASE_DIR. Therefore, I added an according function to qiita_client and qiita, but only delete the file when using "filesystem" protocol OR qiita is run in test mode as I am too skeptical about providing an API endpoint to delete arbitrary files.