### PR TITLE
Push empty files

### DIFF
--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -12,6 +12,7 @@ import time
 import requests
 import threading
 import pandas as pd
+import math
 from json import dumps, loads
 try:
     from json import JSONDecodeError
@@ -927,6 +928,40 @@ class QiitaClient(object):
                 ("File communication protocol '%s' as defined in plugins "
                  "configuration is NOT defined.") % self._plugincoupling)
 
+    def _push_file_in_chunks(self, filepath, fp_target, is_directory=False,
+                             chunk_size=3*1024*1024):
+        """Pushs a file in chunks to Qiita central.
+
+        Parameters
+        ----------
+        filepath : str
+            Filepath to the file whichs content shall be split into chunks.
+        fp_target : str
+            Desired file path in Qiita central - might be different from
+            current filepath pointing to the file that shall be transfered.
+        is_directory : boolean
+            Flag that transferred file is a zipped archive that shall be
+            extracted in Qiita central.
+        chunk_size : int
+            Maximum size in byte for a chunk.
+        """
+        total_chunks = math.ceil(os.path.getsize(filepath) / chunk_size)
+        current_chunk = 1
+        with open(filepath, "rb") as f:
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                self.post(
+                    '/cloud/push_file_to_central/',
+                    files={'file': ("dummy", chunk,
+                                    "application/octet-stream")},
+                    data={"current_chunk": str(current_chunk),
+                          "total_chunks": str(total_chunks),
+                          "target_filepath": fp_target,
+                          'is_directory': 'true' if is_directory else 'false'})
+                current_chunk += 1
+
     def push_file_to_central(self, filepath):
         """Pushs file- or directory content to Qiita's central BASE_DATA_DIR
            directory.
@@ -970,14 +1005,9 @@ class QiitaClient(object):
                 for root, dirnames, filenames in os.walk(filepath):
                     for filename in fnmatch.filter(filenames, "*"):
                         fp = os.path.join(root, filename)
-                        self.post('/cloud/push_file_to_central/',
-                                  files={os.path.join(
-                                      dirpath,
-                                      os.path.dirname(fp)): open(fp, 'rb')})
+                        self._push_file_in_chunks(fp, fp)
             else:
-                self.post(
-                    '/cloud/push_file_to_central/',
-                    files={dirpath: open(filepath, 'rb')})
+                self._push_file_in_chunks(filepath, filepath)
 
             return filepath
 

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -945,12 +945,17 @@ class QiitaClient(object):
         chunk_size : int
             Maximum size in byte for a chunk.
         """
-        total_chunks = math.ceil(os.path.getsize(filepath) / chunk_size)
+        # min 1, because a plugin might want to send empty files, like in tests
+        # for qtp-job-output-folder
+        total_chunks = min(1, math.ceil(os.path.getsize(filepath) / chunk_size))
         current_chunk = 1
         with open(filepath, "rb") as f:
             while True:
                 chunk = f.read(chunk_size)
-                if not chunk:
+                if (not chunk) and (current_chunk > 1):
+                    # end sending chunks if file does not yield more data
+                    # edge case: plugin wants to send an empty file, therefore
+                    # send at least one chunk
                     break
                 self.post(
                     '/cloud/push_file_to_central/',

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -947,7 +947,9 @@ class QiitaClient(object):
         """
         # min 1, because a plugin might want to send empty files, like in tests
         # for qtp-job-output-folder
-        total_chunks = min(1, math.ceil(os.path.getsize(filepath) / chunk_size))
+        total_chunks = min(
+            1,
+            math.ceil(os.path.getsize(filepath) / chunk_size))
         current_chunk = 1
         with open(filepath, "rb") as f:
             while True:

--- a/qiita_client/qiita_client.py
+++ b/qiita_client/qiita_client.py
@@ -945,9 +945,9 @@ class QiitaClient(object):
         chunk_size : int
             Maximum size in byte for a chunk.
         """
-        # min 1, because a plugin might want to send empty files, like in tests
+        # max 1, because a plugin might want to send empty files, like in tests
         # for qtp-job-output-folder
-        total_chunks = min(
+        total_chunks = max(
             1,
             math.ceil(os.path.getsize(filepath) / chunk_size))
         current_chunk = 1


### PR DESCRIPTION
Currently, a file get's transferred in chunks. Sending chunks quits once no more data can get read from the file. This works fine, but for empty files, as they don't yield any chunks. 

To avoid diverging behavior, I've updated the loop such that at least one iteration is done (even if no data is present) to transfer an empty file, i.e. create it in qiita main. Otherwise, qtp-job-output-folder and qp-target-gene tests will fail.